### PR TITLE
remove javadoc linting and show deprecation warnings

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -32,3 +32,6 @@ resolvers ++= Seq(
     "Fuse" at "http://repo.fusesource.com/nexus/content/groups/public"
 )
 
+javacOptions in compile ++= Seq("-g:lines,vars,source", "-deprecation")
+
+javacOptions in doc += "-Xdoclint:none"


### PR DESCRIPTION
split out sbt javaOptions to remove linting on javadoc because any javadoc errors will cause the build to fail when compiling with java 8. Add flag to show deprecation warnings when compiling/building.