### PR TITLE
Add the pieces for converting an ActiveMQ message with headers and pr…

### DIFF
--- a/connectors/activemq/src/main/java/forklift/ActiveMQHeaders.java
+++ b/connectors/activemq/src/main/java/forklift/ActiveMQHeaders.java
@@ -1,0 +1,162 @@
+package forklift;
+
+import forklift.message.Header;
+
+import org.apache.activemq.command.ActiveMQMessage;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.jms.JMSException;
+
+public class ActiveMQHeaders {
+    // Build headers
+    private final static Map<Header, JMSMethodCallI> functions;
+
+    static {
+        Map<Header, JMSMethodCallI> setup = new HashMap<>();
+        setup.put(Header.CorrelationId, new JMSMethodCallI() {
+            public Object get(ActiveMQMessage m) {
+                if (m == null)
+                    return null;
+                return m.getJMSCorrelationID();
+            }
+        });
+        setup.put(Header.DeliveryCount, new JMSMethodCallI() {
+            public Object get(ActiveMQMessage m) {
+                if (m == null)
+                    return null;
+                return m.getRedeliveryCounter();
+            }
+        });
+        setup.put(Header.DeliveryMode, new JMSMethodCallI() {
+            public Object get(ActiveMQMessage m) {
+                if (m == null)
+                    return null;
+                return m.getJMSDeliveryMode();
+            }
+
+        });
+        setup.put(Header.Expiration, new JMSMethodCallI() {
+            public Object get(ActiveMQMessage m) {
+                if (m == null)
+                    return null;
+                return m.getJMSExpiration();
+            }
+
+        });
+        setup.put(Header.GroupID, new JMSMethodCallI() {
+            public Object get(ActiveMQMessage m) {
+                if (m == null)
+                    return null;
+                return m.getGroupID();
+            }
+        });
+        setup.put(Header.GroupSeq, new JMSMethodCallI() {
+            public Object get(ActiveMQMessage m) {
+                if (m == null)
+                    return null;
+                return m.getGroupSequence();
+            }
+        });
+        setup.put(Header.PreviousDestination, new JMSMethodCallI() {
+            public Object get(ActiveMQMessage m) {
+                if (m == null)
+                    return null;
+                try {
+                    return m.getStringProperty("JMSPPreviousDestination");
+                } catch (JMSException e) {
+                    return null;
+                }
+            }
+        });
+        setup.put(Header.Priority, new JMSMethodCallI() {
+            public Object get(ActiveMQMessage m) {
+                if (m == null)
+                    return null;
+                return m.getJMSPriority();
+            }
+        });
+        setup.put(Header.Producer, new JMSMethodCallI() {
+            public Object get(ActiveMQMessage m) {
+                if (m == null)
+                    return null;
+                try {
+                    return m.getStringProperty("JMSPProducer");
+                } catch (JMSException e) {
+                    return null;
+                }
+            }
+        });
+        setup.put(Header.ReplyTo, new JMSMethodCallI() {
+            public Object get(ActiveMQMessage m) {
+                if (m == null)
+                    return null;
+                if (m.getReplyTo() == null)
+                    return null;
+                return m.getReplyTo().toString();
+            }
+        });
+        setup.put(Header.Result, new JMSMethodCallI() {
+            public Object get(ActiveMQMessage m) {
+                if (m == null)
+                    return null;
+                try {
+                    return m.getStringProperty("JMSPProducer");
+                } catch (JMSException e) {
+                    return null;
+                }
+            }
+        });
+        setup.put(Header.ResultDetail, new JMSMethodCallI() {
+            public Object get(ActiveMQMessage m) {
+                if (m == null)
+                    return null;
+                try {
+                    return m.getStringProperty("JMSPResultDetail");
+                } catch (JMSException e) {
+                    return null;
+                }
+            }
+        });
+        setup.put(Header.RetryCount, new JMSMethodCallI() {
+            public Object get(ActiveMQMessage m) {
+                if (m == null)
+                    return null;
+                try {
+                    if (m.getProperty("JMSPRetryCount") == null)
+                        return null;
+                    return m.getIntProperty("JMSPRetryCount");
+                } catch (IOException | JMSException | NumberFormatException e) {
+                    return null;
+                }
+            }
+        });
+        setup.put(Header.Timestamp, new JMSMethodCallI() {
+            public Object get(ActiveMQMessage m) {
+                if (m == null)
+                    return null;
+                return m.getJMSTimestamp();
+            }
+        });
+        setup.put(Header.Type, new JMSMethodCallI() {
+            public Object get(ActiveMQMessage m) {
+                if (m == null)
+                    return null;
+                return m.getJMSType();
+            }
+        });
+
+        functions = Collections.unmodifiableMap(setup);
+    }
+
+    public static Map<Header, JMSMethodCallI> getFunctions() {
+        return functions;
+    }
+
+    public interface JMSMethodCallI {
+        Object get(ActiveMQMessage m);
+    }
+}

--- a/core/src/main/java/forklift/connectors/ForkliftMessage.java
+++ b/core/src/main/java/forklift/connectors/ForkliftMessage.java
@@ -1,6 +1,5 @@
 package forklift.connectors;
 
-import forklift.decorators.Headers;
 import forklift.message.Header;
 
 import java.util.Map;
@@ -12,7 +11,7 @@ public class ForkliftMessage {
     private String msg;
     private boolean flagged;
     private String warning;
-    private Map<Header, String> headers;
+    private Map<Header, Object> headers;
     private Map<String, Object> properties;
 
     public ForkliftMessage() {
@@ -50,11 +49,11 @@ public class ForkliftMessage {
         this.flagged = flagged;
     }
 
-    public void setHeaders(Map<Header, String> headers) {
+    public void setHeaders(Map<Header, Object> headers) {
         this.headers = headers;
     }
 
-    public Map<Header, String> getHeaders() {
+    public Map<Header, Object> getHeaders() {
         return headers;
     }
 

--- a/core/src/test/java/forklift/ConsumerTest.java
+++ b/core/src/test/java/forklift/ConsumerTest.java
@@ -115,7 +115,7 @@ public class ConsumerTest {
         ForkliftMessage msg = new ForkliftMessage(jmsMsg);
         msg.setMsg("{}");
 
-        Map<Header, String> headers = new HashMap<>();
+        Map<Header, Object> headers = new HashMap<>();
         headers.put(Header.DeliveryCount, "3");
         headers.put(Header.Producer, "testing");
         headers.put(Header.Priority, "1");


### PR DESCRIPTION
…operties over to a forklift message. This is the next piece into getting headers and properties into forklift and usable. Needed to change the type on the forklift message headers to be a map of Header -> Object. Should have known this since we already have a type on our Header enums.