### PR TITLE
Fix path error is quick start guide with regards to the Using Node.js…

### DIFF
--- a/doc/forklift.adoc
+++ b/doc/forklift.adoc
@@ -492,7 +492,7 @@ that needs fixed in order to let our node application work.
 
 Within the following file, modify the code
 
-.node_modules/stomp-client/libframe.js
+.node_modules/stomp-client/lib/frame.js
 [source,javascript]
 ----
 if (this.body.length > 0) {


### PR DESCRIPTION
This will fix an error in the "Quickstart Guide" for fixing the stomp client in node.js