### PR TITLE
Logback library update

### DIFF
--- a/server/build.sbt
+++ b/server/build.sbt
@@ -15,24 +15,23 @@ initialize := {
 }
 
 libraryDependencies ++= Seq(
-  "com.github.dcshock" % "forklift" % "0.8",
-  "com.github.dcshock" % "forklift-activemq" % "0.5",
-  "com.github.dcshock" % "forklift-replay" % "0.5",
-  "com.github.dcshock" % "forklift-retry" % "0.5",
+  "com.github.dcshock" % "forklift"           % "0.8",
+  "com.github.dcshock" % "forklift-activemq"  % "0.5",
+  "com.github.dcshock" % "forklift-replay"    % "0.5",
+  "com.github.dcshock" % "forklift-retry"     % "0.5",
   "com.github.dcshock" % "consul-rest-client" % "0.6",
-  "ch.qos.logback" % "logback-classic" % "1.0.13",
-  "org.apache.geronimo.specs" % "geronimo-jms_1.1_spec" % "1.1.1",
   "org.apache.activemq" % "activemq-all" % "5.8.0",
+  "org.apache.geronimo.specs" % "geronimo-jms_1.1_spec" % "1.1.1",
   "args4j" % "args4j" % "2.0.31",
-  "ch.qos.logback.contrib" % "logback-json-core" % "0.1.2",
+  "org.codehaus.janino" % "janino" % "2.6.1",
+  "ch.qos.logback" % "logback-classic" % "1.0.13",
+  "ch.qos.logback.contrib" % "logback-json-core"    % "0.1.2",
   "ch.qos.logback.contrib" % "logback-json-classic" % "0.1.2",
-  "ch.qos.logback.contrib" % "logback-jackson" % "0.1.2",
+  "ch.qos.logback.contrib" % "logback-jackson"      % "0.1.2",
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.5.1",
   "javax.inject" % "javax.inject" % "1",
-  "org.codehaus.janino" % "janino" % "2.6.1",
-  "com.novocode" % "junit-interface" % "0.10" % "test",
-  "commons-io" % "commons-io" % "2.4" % "test",
-  "junit" % "junit" % "4.11"  % "test"
+  "com.novocode" % "junit-interface" % "0.11" % "test",
+  "commons-io" % "commons-io" % "2.4" % "test"
 )
 
 resolvers ++= Seq(

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -24,7 +24,7 @@ libraryDependencies ++= Seq(
   "org.apache.geronimo.specs" % "geronimo-jms_1.1_spec" % "1.1.1",
   "args4j" % "args4j" % "2.0.31",
   "org.codehaus.janino" % "janino" % "2.6.1",
-  "ch.qos.logback" % "logback-classic" % "1.0.13",
+  "ch.qos.logback" % "logback-classic" % "1.1.2",
   "ch.qos.logback.contrib" % "logback-json-core"    % "0.1.2",
   "ch.qos.logback.contrib" % "logback-json-classic" % "0.1.2",
   "ch.qos.logback.contrib" % "logback-jackson"      % "0.1.2",


### PR DESCRIPTION
Without this update, the janino stuff doesn't work (allowing for setting environment variable DEV_LOGGING to disable json formatted in logs).