### PR TITLE
Adding Key Value producer method "send(Map<String, String> ..)"

### DIFF
--- a/connectors/activemq/src/main/java/forklift/producers/ActiveMQProducer.java
+++ b/connectors/activemq/src/main/java/forklift/producers/ActiveMQProducer.java
@@ -11,6 +11,7 @@ import forklift.producers.ProducerException;
 
 import org.apache.activemq.command.ActiveMQMessage;
 
+import java.lang.StringBuilder;
 import java.util.Map;
 import java.util.UUID;
 
@@ -59,6 +60,18 @@ public class ActiveMQProducer implements ForkliftProducerI {
         } catch (Exception e) {
             throw new ProducerException("Failed to send message", e);
         }
+    }
+
+    @Override
+    /**
+    * Send in a map and the producer will convert it to a key-value pair before sending a ForkliftMessage
+    * @param message - Map<String, String> of the message/data that needs to be sent
+    * @return String - JMSCorrelationID
+    **/
+    public String send(Map<String, String> message) throws ProducerException {
+        final StringBuilder output = new StringBuilder();
+        message.forEach((k, v) -> output.append(k).append('=').append(v).append('\n'));
+        return send(new ForkliftMessage(output.toString()));
     }
 
     @Override

--- a/connectors/activemq/src/test/java/forklift/activemq/test/ProducerTest.java
+++ b/connectors/activemq/src/test/java/forklift/activemq/test/ProducerTest.java
@@ -140,6 +140,29 @@ public class ProducerTest {
         Assert.assertTrue(called.get() > 0);
     }
 
+    @Test 
+    public void testSendKeyValueMessage() throws JMSException, ConnectorException, ProducerException {
+        int msgCount = 10;
+        ForkliftProducerI producer = TestServiceManager.getConnector().getQueueProducer("q2");
+        for (int i = 0; i < msgCount; i++) {
+            final Map<String, String> m = new HashMap<>();
+            m.put("x", "producer key value send test");
+            producer.send(m);
+        }
+        
+        final Consumer c = new Consumer(getClass(), TestServiceManager.getConnector());
+        // Shutdown the consumer after all the messages have been processed.
+        c.setOutOfMessages((listener) -> {
+            listener.shutdown();
+            Assert.assertTrue("called was not == " + msgCount, called.get() == msgCount);
+        });
+
+        // Start the consumer.
+        c.listen();
+
+        Assert.assertTrue(called.get() > 0);
+    }
+
     @Test
     public void testSendTripleThreat() throws JMSException, ConnectorException, ProducerException {
         int msgCount = 10;

--- a/core/src/main/java/forklift/producers/ForkliftProducerI.java
+++ b/core/src/main/java/forklift/producers/ForkliftProducerI.java
@@ -14,6 +14,7 @@ public interface ForkliftProducerI {
     String send(String message) throws ProducerException;
     String send(ForkliftMessage message) throws ProducerException;
     String send(Object message) throws ProducerException;
+    String send(Map<String, String> message) throws ProducerException;
     String send(Map<Header, Object> headers, 
                 Map<String, Object> properties,
                 ForkliftMessage message) throws ProducerException;


### PR DESCRIPTION
# Bug

The key-value pair Consumer option does not have a corresponding Producer method.

# Story

Developer: *"I want to create a producer that can send to SomeConsumer, but I don't have the documentation, lets look at the source."*

```
@Message
Map<String, String> msg;

@OnValidate
public bool validate() {
    returm msg.hasKey("a") && msg.hasKey("b");
}
```

Developer: *"Oh, I get it, I just need to send a Map like this."*

```
Map<String, String> msg = new HashMap<>();
msg.set("a", "data1");
msg.set("b", "data2");
forkliftProducer.send(msg);
```

Forklift: `validation failed`

Developer: *???*

# Explanation

The map was serialized as JSON in the Producer, but deserialized as key-value pairs on the Consumer, even though they share the same type.)

# Fix

Add an additional `send(...)` method so that sending a Map<String, String> serializes to key-value pairs instead of JSON.

# Testing/Deployment

This changes both forklift connector plugin API and the forklift plugins that depend on it. It requires that you locally deploy a new forklift core before you build or test the ActiveMQProducer plugin.