### PR TITLE
Opt-in to new travisci infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ scala:
     - "2.11.4"
 jdk:
     - oraclejdk8
+sudo: false


### PR DESCRIPTION
The only difference between my [working builds](https://travis-ci.org/jgsofi/forklift/builds/75168901) and the dcshock [failing builds](https://travis-ci.org/dcshock/forklift/builds/71147633) is that the dcshock TravisCI is still grandfathered in to the old build infrastructure. This upgrades to the new, supposedly faster infrastructure.