### PR TITLE
Changed default port to 3001

### DIFF
--- a/plugins/gui/Dockerfile
+++ b/plugins/gui/Dockerfile
@@ -6,7 +6,7 @@ ADD . /forklift-gui
 WORKDIR /forklift-gui
 
 # Expose the default node hosting port.
-EXPOSE 3000
+EXPOSE 3001
 
 RUN chmod 755 /forklift-gui/bin/run
 ENTRYPOINT ["/forklift-gui/bin/run"]

--- a/plugins/gui/bin/start
+++ b/plugins/gui/bin/start
@@ -8,7 +8,7 @@ var child = new forever.Monitor('./bin/www', {
     options: [],
     env: {
         TZ: process.env.TZ || "America/New_York",
-        PORT: process.env.PORT || 3000
+        PORT: process.env.PORT || 3001
     }
 });
 


### PR DESCRIPTION
This is so that it can run alongside Noise in the docker compose environment.