### PR TITLE
Unwrap InvocationTargetExceptions thrown by consumer

### DIFF
--- a/core/src/main/java/forklift/consumer/MessageRunnable.java
+++ b/core/src/main/java/forklift/consumer/MessageRunnable.java
@@ -11,6 +11,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.util.ArrayList;
@@ -217,6 +218,10 @@ public class MessageRunnable implements Runnable {
         try {
             return func.get();
         } catch (Throwable e) {
+            if (e instanceof InvocationTargetException) {
+                e = ((InvocationTargetException) e).getTargetException();
+            }
+
             StringWriter sw = new StringWriter();
             e.printStackTrace(new PrintWriter(sw)); // stack trace as a string
 


### PR DESCRIPTION
#### Changes:
- If the consumer handler code gives an `InvocationTargetException`, print it as its original error

Just a minor quality of life improvement so that consumer exceptions don't always start with all the `InvocationTargetException` boilerplate.