### PR TITLE
Fix Tests on Travis and Circle CI

### DIFF
--- a/connectors/activemq/build.sbt
+++ b/connectors/activemq/build.sbt
@@ -38,6 +38,9 @@ lazy val testDependencies = Seq(
 
 libraryDependencies ++= testDependencies.map(_ % "test")
 
+// Integration tests use embedded servers.  We can only allow one instance at a time
+// so disable parallel test execution
+parallelExecution in Test := false
 testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a")
 
 // Remove scala dependency for pure Java libraries

--- a/connectors/activemq/build.sbt
+++ b/connectors/activemq/build.sbt
@@ -38,6 +38,8 @@ lazy val testDependencies = Seq(
 
 libraryDependencies ++= testDependencies.map(_ % "test")
 
+testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a")
+
 // Remove scala dependency for pure Java libraries
 autoScalaLibrary := false
 

--- a/connectors/activemq/src/test/java/forklift/activemq/test/ResponseTest.java
+++ b/connectors/activemq/src/test/java/forklift/activemq/test/ResponseTest.java
@@ -79,7 +79,7 @@ public class ResponseTest {
         // Produce messages with a sync producer that connects the producer, resolver, and response uri together.
         try (ForkliftSyncProducerI<Map<String, String>> producer = new ForkliftSyncProducer<>(
                 connector.getQueueProducer("response"), resolver, "queue://" + ResponseConsumerMap.class.getAnnotation(Queue.class).value())) {
-            for (int i = 0; i < 100; i++)
+            for (int i = 0; i < 10; i++)
                 futures.add(producer.send("{}"));
         }
 
@@ -121,7 +121,7 @@ public class ResponseTest {
         // Produce messages with a sync producer that connects the producer, resolver, and response uri together.
         try (ForkliftSyncProducerI<ResponseObj> producer = new ForkliftSyncProducer<>(
                 connector.getQueueProducer("response"), resolver, "queue://" + ResponseConsumerMap.class.getAnnotation(Queue.class).value())) {
-            for (int i = 0; i < 100; i++)
+            for (int i = 0; i < 10; i++)
                 futures.add(producer.send("{}"));
         }
 

--- a/connectors/activemq/src/test/java/forklift/activemq/test/ResponseTest.java
+++ b/connectors/activemq/src/test/java/forklift/activemq/test/ResponseTest.java
@@ -27,6 +27,9 @@ public class ResponseTest {
         TestServiceManager.stop();
     }
 
+    private static final int maxTimeouts = 5;
+    private int timeouts = 0;
+
 //    @Test
     public void testStringResp() throws Exception {
         final ForkliftConnectorI connector = TestServiceManager.getConnector();
@@ -84,7 +87,11 @@ public class ResponseTest {
         ResponseConsumerMap.resolver = resolver;
         final Consumer c = new Consumer(ResponseConsumerMap.class, TestServiceManager.getForklift());
         c.setOutOfMessages((listener) -> {
-            listener.shutdown();
+            timeouts++;
+
+            if (futures.stream().allMatch(future -> future.isDone()) || timeouts > maxTimeouts) {
+                listener.shutdown();
+            }
         });
         c.listen();
 
@@ -122,7 +129,11 @@ public class ResponseTest {
         ResponseConsumerObj.resolver = resolver;
         final Consumer c = new Consumer(ResponseConsumerObj.class, TestServiceManager.getForklift());
         c.setOutOfMessages((listener) -> {
-            listener.shutdown();
+            timeouts++;
+
+            if (futures.stream().allMatch(future -> future.isDone()) || timeouts > maxTimeouts) {
+                listener.shutdown();
+            }
         });
         c.listen();
 

--- a/connectors/kafka/build.sbt
+++ b/connectors/kafka/build.sbt
@@ -50,6 +50,7 @@ libraryDependencies ++= testDependencies.map(_ % "test")
 // Integration tests use embedded servers.  We can only allow one instance at a time
 // so disable parallel test execution
 parallelExecution in Test := false
+testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a")
 
 // avro settings
 (javaSource in avroConfig) := baseDirectory(_/"target/generated-sources").value

--- a/connectors/kafka/src/test/java/forklift/integration/AvroMessageTests.java
+++ b/connectors/kafka/src/test/java/forklift/integration/AvroMessageTests.java
@@ -58,7 +58,11 @@ public class AvroMessageTests extends BaseIntegrationTest {
         final Consumer c = new Consumer(AvroMessageTests.RegisteredAvroConsumer.class, forklift);
         // Shutdown the consumer after all the messages have been processed.
         c.setOutOfMessages((listener) -> {
-            listener.shutdown();
+            timeouts++;
+
+            if (sentMessageIds.equals(consumedMessageIds) || timeouts > maxTimeouts) {
+                listener.shutdown();
+            }
         });
         // Start the consumer.
         c.listen();
@@ -83,7 +87,11 @@ public class AvroMessageTests extends BaseIntegrationTest {
         final Consumer c = new Consumer(AvroMessageTests.RegisteredAvroConsumer.class, forklift);
         // Shutdown the consumer after all the messages have been processed.
         c.setOutOfMessages((listener) -> {
-            listener.shutdown();
+            timeouts++;
+
+            if (sentMessageIds.equals(consumedMessageIds) || timeouts > maxTimeouts) {
+                listener.shutdown();
+            }
         });
         // Start the consumer.
         c.listen();

--- a/connectors/kafka/src/test/java/forklift/integration/BaseIntegrationTest.java
+++ b/connectors/kafka/src/test/java/forklift/integration/BaseIntegrationTest.java
@@ -39,6 +39,8 @@ public abstract class BaseIntegrationTest {
     protected static Set<String> sentMessageIds = ConcurrentHashMap.newKeySet();
     protected static Set<String> consumedMessageIds = ConcurrentHashMap.newKeySet();
     protected TestServiceManager serviceManager;
+    protected final int maxTimeouts = 5;
+    protected int timeouts = 0;
 
     @After
     public void after() {

--- a/connectors/kafka/src/test/java/forklift/integration/ForkliftMessageTests.java
+++ b/connectors/kafka/src/test/java/forklift/integration/ForkliftMessageTests.java
@@ -58,13 +58,18 @@ public class ForkliftMessageTests extends BaseIntegrationTest {
         final Consumer c = new Consumer(ForkliftMessageConsumer.class, forklift);
         // Shutdown the consumer after all the messages have been processed.
         c.setOutOfMessages((listener) -> {
-            listener.shutdown();
-            assertTrue("Message properties were overwritten", isPropOverwritten == false);
-            assertTrue("Message properties were not set", isPropsSet == true);
+            timeouts++;
+
+            if (sentMessageIds.equals(consumedMessageIds) || timeouts > maxTimeouts) {
+                listener.shutdown();
+            }
         });
         // Start the consumer.
         c.listen();
         messageAsserts();
+
+        assertTrue("Message properties were overwritten", isPropOverwritten == false);
+        assertTrue("Message properties were not set", isPropsSet == true);
     }
 
     @Queue("forklift-string-topic")

--- a/connectors/kafka/src/test/java/forklift/integration/MapMessageTests.java
+++ b/connectors/kafka/src/test/java/forklift/integration/MapMessageTests.java
@@ -28,7 +28,11 @@ public class MapMessageTests extends BaseIntegrationTest {
         final Consumer c = new Consumer(ForkliftMapConsumer.class, forklift);
         // Shutdown the consumer after all the messages have been processed.
         c.setOutOfMessages((listener) -> {
-            listener.shutdown();
+            timeouts++;
+
+            if (sentMessageIds.equals(consumedMessageIds) || timeouts > maxTimeouts) {
+                listener.shutdown();
+            }
         });
 
         // Start the consumer.

--- a/connectors/kafka/src/test/java/forklift/integration/ObjectMessageTests.java
+++ b/connectors/kafka/src/test/java/forklift/integration/ObjectMessageTests.java
@@ -29,7 +29,11 @@ public class ObjectMessageTests extends BaseIntegrationTest {
         final Consumer c = new Consumer(ForkliftObjectConsumer.class, forklift);
         // Shutdown the consumer after all the messages have been processed.
         c.setOutOfMessages((listener) -> {
-            listener.shutdown();
+            timeouts++;
+
+            if (sentMessageIds.equals(consumedMessageIds) || timeouts > maxTimeouts) {
+                listener.shutdown();
+            }
         });
 
         // Start the consumer.

--- a/connectors/kafka/src/test/java/forklift/integration/StringMessageTests.java
+++ b/connectors/kafka/src/test/java/forklift/integration/StringMessageTests.java
@@ -30,7 +30,11 @@ public class StringMessageTests extends BaseIntegrationTest {
         final Consumer c = new Consumer(StringConsumer.class, forklift);
         // Shutdown the consumer after all the messages have been processed.
         c.setOutOfMessages((listener) -> {
-            listener.shutdown();
+            timeouts++;
+
+            if (sentMessageIds.equals(consumedMessageIds) || timeouts > maxTimeouts) {
+                listener.shutdown();
+            }
         });
         // Start the consumer.
         c.listen();
@@ -54,7 +58,11 @@ public class StringMessageTests extends BaseIntegrationTest {
                                      forklift);
         // Shutdown the consumer after all the messages have been processed.
         c.setOutOfMessages((listener) -> {
-            listener.shutdown();
+            timeouts++;
+
+            if (sentMessageIds.equals(consumedMessageIds) || timeouts > maxTimeouts) {
+                listener.shutdown();
+            }
         });
         // Start the consumer.
         c.listen();

--- a/connectors/kafka/src/test/java/forklift/integration/server/TestServiceManager.java
+++ b/connectors/kafka/src/test/java/forklift/integration/server/TestServiceManager.java
@@ -50,6 +50,7 @@ public class TestServiceManager {
             Thread.sleep(2000); //kafka doesn't seem to be quite ready after it starts listening on its port
             executor.execute(schemaRegistry);
             waitService("127.0.0.1", schemaPort);
+            Thread.sleep(1000); //give the schema-registry a little time also
         } catch (Throwable e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
#### Changes:
- Improve JUnit test logging (the `-q` option seemed to not give error output sometimes, would use it otherwise)
- Disallow parallel execution for tests of the activemq connector, since they use `TestServiceManager`
- Allow `outOfMessage` handlers in failing tests to have a set number of timeouts before they force the consumer to stop.
- Limit number of messages sent in `ResponseTest` tests, since Circle CI would still go over the timeout limit sometimes
- Give schema-registry 1000 ms to start up (sometimes it just wasn't ready)

Basically, the main problem is that the CI servers are slow, so some delay has to be allowed for in tests. These changes have made the tests pass on Travis and Circle CI as far as I have seen.

----

Please Review: @dcshock @AFrieze 