### PR TITLE
Wip/forklift kafka incremental controller

### DIFF
--- a/connectors/kafka/build.sbt
+++ b/connectors/kafka/build.sbt
@@ -4,6 +4,7 @@ name := "forklift-kafka"
 
 version := "1.0"
 
+//required for some test dependencies
 scalaVersion := "2.11.7"
 
 javacOptions ++= Seq("-source", "1.8")

--- a/connectors/kafka/src/main/java/forklift/connectors/KafkaConnector.java
+++ b/connectors/kafka/src/main/java/forklift/connectors/KafkaConnector.java
@@ -105,7 +105,7 @@ public class KafkaConnector implements ForkliftConnectorI {
     @Override
     public synchronized ForkliftConsumerI getTopic(String name) throws ConnectorException {
         KafkaController controller = controllers.get(name);
-        if(controller != null && controller.isRunning()){
+        if (controller != null && controller.isRunning()) {
             log.warn("Consumer for topic already exists under this controller's groupname.  Messages will be divided amongst consumers.");
         } else {
             controller = createController(name);

--- a/connectors/kafka/src/main/java/forklift/consumer/KafkaTopicConsumer.java
+++ b/connectors/kafka/src/main/java/forklift/consumer/KafkaTopicConsumer.java
@@ -27,9 +27,6 @@ public class KafkaTopicConsumer implements ForkliftConsumerI {
      * <p>
      * Retrieves the {@link forklift.message.MessageStream#nextRecord(String, long) nextRecord} from the messageStream.
      * If no record is available within the specified timeout, null is returned.
-     * <p>
-     * <strong>Note:</strong> Because we do not wish to poll for kafka topics until we are actively receiving messages, this method is
-     * also responsible for calling {@link forklift.controller.KafkaController#addTopic(String) addTopic} on the kafkaController.
      *
      * @param timeout the time in milliseconds to wait for a record to become available
      * @return a message if one is available, else null
@@ -52,8 +49,7 @@ public class KafkaTopicConsumer implements ForkliftConsumerI {
     /**
      * {@inheritDoc}
      * <p>
-     * Removes this consumer's topic from the controller.  Future calls to {@link #receive(long) receive} will re-add the
-     * topic to the controller.
+     * Closes this consumer and stops the controller.
      * </p>
      */
     @Override

--- a/connectors/kafka/src/main/java/forklift/consumer/KafkaTopicConsumer.java
+++ b/connectors/kafka/src/main/java/forklift/consumer/KafkaTopicConsumer.java
@@ -35,7 +35,11 @@ public class KafkaTopicConsumer implements ForkliftConsumerI {
      */
     @Override
     public ForkliftMessage receive(long timeout) throws ConnectorException {
-        addTopicIfMissing();
+        try {
+            addTopicIfMissing();
+        } catch (InterruptedException e) {
+            throw new ConnectorException("Topic add interrupted");
+        }
         //ensure that the controller is still running
         if (!controller.isRunning()) {
             throw new ConnectorException("Connection to Kafka Controller lost");
@@ -47,7 +51,7 @@ public class KafkaTopicConsumer implements ForkliftConsumerI {
         }
     }
 
-    private void addTopicIfMissing() {
+    private void addTopicIfMissing() throws InterruptedException {
         if (!topicAdded) {
             synchronized (this) {
                 if (!topicAdded) {
@@ -67,6 +71,10 @@ public class KafkaTopicConsumer implements ForkliftConsumerI {
      */
     @Override
     public void close() {
-        controller.removeTopic(topic);
+        try {
+            controller.removeTopic(topic);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
     }
 }

--- a/connectors/kafka/src/main/java/forklift/consumer/KafkaTopicConsumer.java
+++ b/connectors/kafka/src/main/java/forklift/consumer/KafkaTopicConsumer.java
@@ -14,7 +14,6 @@ public class KafkaTopicConsumer implements ForkliftConsumerI {
     private final String topic;
     private final KafkaController controller;
     private final ReadableMessageStream messageStream;
-    private volatile boolean topicAdded = false;
 
     public KafkaTopicConsumer(String topic, KafkaController controller) {
         this.topic = topic;

--- a/connectors/kafka/src/main/java/forklift/controller/KafkaController.java
+++ b/connectors/kafka/src/main/java/forklift/controller/KafkaController.java
@@ -140,10 +140,6 @@ public class KafkaController {
             throw t;
         } finally {
             running = false;
-            synchronized (this) {
-                //wake up any threads waiting on a control loop operation
-                this.notifyAll();
-            }
             try {
                 Map<TopicPartition, OffsetAndMetadata> finalOffsets = new HashMap<>();
                 if (failedOffset != null) {

--- a/connectors/kafka/src/main/java/forklift/controller/KafkaController.java
+++ b/connectors/kafka/src/main/java/forklift/controller/KafkaController.java
@@ -116,7 +116,6 @@ public class KafkaController {
     public void stop(long timeout, TimeUnit timeUnit) throws InterruptedException {
         running = false;
         kafkaConsumer.wakeup();
-       // executor.shutdownNow();
         executor.shutdown();
         if (!executor.awaitTermination(timeout, timeUnit)) {
             log.error("Failed to stop KafkaController in {} {}", timeout, timeUnit);

--- a/connectors/kafka/src/main/java/forklift/controller/KafkaController.java
+++ b/connectors/kafka/src/main/java/forklift/controller/KafkaController.java
@@ -12,6 +12,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.WakeupException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -24,6 +25,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import javax.annotation.concurrent.GuardedBy;
 
 /**
  * Manages the {@link org.apache.kafka.clients.consumer.KafkaConsumer} thread.  Polled records are sent to the MessageStream. Commits
@@ -41,10 +45,13 @@ public class KafkaController {
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
     private final KafkaConsumer<?, ?> kafkaConsumer;
     private final MessageStream messageStream;
-    private volatile boolean topicsChanged = false;
     private AcknowledgedRecordHandler acknowledgmentHandler = new AcknowledgedRecordHandler();
     private Map<TopicPartition, OffsetAndMetadata> failedOffset = null;
     private Map<TopicPartition, AtomicInteger> flowControl = new ConcurrentHashMap<>();
+    @GuardedBy("this")
+    private String topicToAdd;
+    @GuardedBy("this")
+    private String topicToRemove;
 
     public KafkaController(KafkaConsumer<?, ?> kafkaConsumer, MessageStream messageStream) {
         this.kafkaConsumer = kafkaConsumer;
@@ -67,12 +74,18 @@ public class KafkaController {
      * @param topic the topic to subscribe to
      * @return true if the topic was added, false if already added
      */
-    public synchronized boolean addTopic(String topic) {
+    public synchronized boolean addTopic(String topic) throws InterruptedException {
+        while (topicToAdd != null) {
+            this.wait();
+        }
         if (!topics.contains(topic)) {
-            messageStream.addTopic(topic);
-            topics.add(topic);
-            topicsChanged = true;
+            this.topicToAdd = topic;
+            //Notify that topics have changed
             this.notifyAll();
+            while (this.topicToAdd != null && running) {
+                //wait for the control loop to add the topic
+                this.wait();
+            }
             return true;
         }
         return false;
@@ -85,13 +98,21 @@ public class KafkaController {
      * @param topic the topic to remove
      * @return true if the topic was removed, false if it wasn't present
      */
-    public synchronized boolean removeTopic(String topic) {
-        boolean removed = topics.remove(topic);
-        if (removed) {
-            messageStream.removeTopic(topic);
-            topicsChanged = true;
+    public synchronized boolean removeTopic(String topic) throws InterruptedException {
+        while (topicToRemove != null) {
+            this.wait();
         }
-        return removed;
+        if (topics.contains(topic)) {
+            this.topicToRemove = topic;
+            //Notify that topics have changed
+            this.notifyAll();
+            while (this.topicToRemove != null && running) {
+                //wait for the control loop to remove the topic
+                this.wait();
+            }
+            return true;
+        }
+        return false;
     }
 
     /**
@@ -157,16 +178,17 @@ public class KafkaController {
     private void controlLoop() {
         try {
             while (running) {
-                boolean updatedAssignment = false;
-                if (topics.size() == 0) {
-                    commitPendingAndWaitForTopics();
+                boolean updatedAssignment;
+                synchronized (this) {
+                    updatedAssignment = processTopicChanges();
+                    //notify any threads waiting on processing of the topic changes
+                    this.notifyAll();
+                    if (topics.size() == 0) {
+                        waitForTopicToAdd();
+                        continue;
+                    }
                 }
-                if (topicsChanged) {
-                    commitPendingOffsetsForRemovedTopics();
-                    kafkaConsumer.subscribe(topics, new RebalanceListener());
-                    updatedAssignment = true;
-                }
-                ConsumerRecords<?, ?> records = flowControlledPoll();
+                ConsumerRecords<?, ?> records = pollForRecords(updatedAssignment);
                 //Update the assignment before adding records to stream
                 if (updatedAssignment) {
                     updateAssignment();
@@ -184,6 +206,10 @@ public class KafkaController {
             throw t;
         } finally {
             running = false;
+            synchronized (this) {
+                //wake up any threads waiting on a control loop operation
+                this.notifyAll();
+            }
             try {
                 Map<TopicPartition, OffsetAndMetadata> finalOffsets = new HashMap<>();
                 if (failedOffset != null) {
@@ -212,18 +238,43 @@ public class KafkaController {
         }
     }
 
-    private void commitPendingAndWaitForTopics() throws InterruptedException {
-        //check if the last remaining topic was removed
-        if (kafkaConsumer.assignment().size() > 0) {
-            Map<TopicPartition, OffsetAndMetadata>
-                            offsets =
-                            acknowledgmentHandler.removePartitions(kafkaConsumer.assignment());
-            commitOffsets(offsets);
-            kafkaConsumer.unsubscribe();
+    private boolean processTopicChanges() throws InterruptedException {
+        boolean topicsChanged = processTopicAdd();
+        topicsChanged = processTopicRemoved() || topicsChanged;
+        if (topicsChanged) {
+            kafkaConsumer.subscribe(topics, new RebalanceListener());
         }
+        return topicsChanged;
+    }
+
+    private boolean processTopicAdd() {
+        if (topicToAdd != null) {
+            topics.add(topicToAdd);
+            messageStream.addTopic(topicToAdd);
+            topicToAdd = null;
+            return true;
+        }
+        return false;
+    }
+
+    private boolean processTopicRemoved() throws InterruptedException {
+        if (topicToRemove != null) {
+            topics.remove(topicToRemove);
+            messageStream.removeTopic(topicToRemove);
+            Set<TopicPartition> removed = kafkaConsumer.assignment().stream().filter(partition -> !topics.contains(partition.topic())).collect(Collectors.toSet());
+            Map<TopicPartition, OffsetAndMetadata> offsets = acknowledgmentHandler.removePartitions(removed);
+            removed.forEach(partition -> flowControl.remove(partition));
+            commitOffsets(offsets);
+            topicToRemove = null;
+            return true;
+        }
+        return false;
+    }
+
+    private void waitForTopicToAdd() throws InterruptedException {
         synchronized (this) {
             //recheck wait condition inside synchronized block
-            while (topics.size() == 0) {
+            while (topicToAdd == null) {
                 //pause the polling thread until a topic comes in
                 log.debug("controlLoop waiting for topic");
                 this.wait();
@@ -231,20 +282,15 @@ public class KafkaController {
         }
     }
 
-    private void commitPendingOffsetsForRemovedTopics() throws InterruptedException {
-        Set<TopicPartition> removed = new HashSet<>();
-        //synchronized to avoid letting the topic set change
-        synchronized (this) {
-            for (TopicPartition partition : kafkaConsumer.assignment()) {
-                if (!topics.contains(partition.topic())) {
-                    removed.add(partition);
-                }
-            }
-            topicsChanged = false;
+    private ConsumerRecords<?, ?> pollForRecords(boolean updatedAssignment) throws InterruptedException {
+        /**
+         * if we have an updated assignment, we cannot do a flow controlled poll as the flowControl collection has not been
+         * updated and cannot be updated until the kafkaConsumer.assignment is updated through a call to kafkaConsumer.poll
+         */
+        if (updatedAssignment) {
+            return kafkaConsumer.poll(100);
         }
-        //commit any removed partitions before we unsubscribe them
-        Map<TopicPartition, OffsetAndMetadata> offsets = acknowledgmentHandler.removePartitions(removed);
-        commitOffsets(offsets);
+        return flowControlledPoll();
     }
 
     private ConsumerRecords<?, ?> flowControlledPoll() throws InterruptedException {
@@ -260,6 +306,7 @@ public class KafkaController {
         }
         kafkaConsumer.pause(paused);
         kafkaConsumer.resume(unpaused);
+
         if (unpaused.size() == 0 && paused.size() > 0) {
             synchronized (this) {
                 //wait for flowControl to notify us, resume after a short pause to allow for heartbeats

--- a/connectors/kafka/src/main/java/forklift/controller/KafkaController.java
+++ b/connectors/kafka/src/main/java/forklift/controller/KafkaController.java
@@ -263,7 +263,7 @@ public class KafkaController {
         if (topicToRemove != null) {
             topics.remove(topicToRemove);
             messageStream.removeTopic(topicToRemove);
-            Set<TopicPartition> removed = kafkaConsumer.assignment().stream().filter(partition -> !topics.contains(partition.topic())).collect(Collectors.toSet());
+            Set<TopicPartition> removed = kafkaConsumer.assignment().stream().filter(partition -> partition.topic().equals(topicToRemove)).collect(Collectors.toSet());
             Map<TopicPartition, OffsetAndMetadata> offsets = acknowledgmentHandler.removePartitions(removed);
             removed.forEach(partition -> flowControl.remove(partition));
             commitOffsets(offsets);

--- a/connectors/kafka/src/main/java/forklift/controller/KafkaController.java
+++ b/connectors/kafka/src/main/java/forklift/controller/KafkaController.java
@@ -239,8 +239,10 @@ public class KafkaController {
     }
 
     private boolean processTopicChanges() throws InterruptedException {
-        boolean topicsChanged = processTopicAdd();
-        topicsChanged = processTopicRemoved() || topicsChanged;
+        boolean topicsAdded = processTopicAdd();
+        boolean topicsRemoved = processTopicRemoved();
+        boolean topicsChanged = topicsAdded || topicsRemoved;
+
         if (topicsChanged) {
             kafkaConsumer.subscribe(topics, new RebalanceListener());
         }

--- a/connectors/kafka/src/test/java/forklift/connectors/KafkaControllerTests.java
+++ b/connectors/kafka/src/test/java/forklift/connectors/KafkaControllerTests.java
@@ -34,6 +34,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class KafkaControllerTests {
 
+    String topic1 = "topic1";
     @Mock
     private MessageStream messageStream;
 
@@ -48,68 +49,12 @@ public class KafkaControllerTests {
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        this.controller = new KafkaController(kafkaConsumer, messageStream);
+        this.controller = new KafkaController(kafkaConsumer, messageStream, topic1);
     }
 
     @After
     public void teardown() throws InterruptedException {
         this.controller.stop(500, TimeUnit.MILLISECONDS);
-    }
-
-    @Test
-    public void addTopicTrueTest() throws InterruptedException {
-        this.controller.start();
-        String topic1 = "topic1";
-        boolean added = this.controller.addTopic(topic1);
-        assertEquals(true, added);
-    }
-
-    @Test
-    public void addingTheSameTopicRepeatedlyDoesntLock() throws InterruptedException {
-        ExecutorService executor = Executors.newSingleThreadExecutor();
-        this.controller.start();
-        String topic1 = "topic1";
-        AtomicInteger timesAdded = new AtomicInteger(0);
-        int timesToAdd = 10;
-        for (int i = 0; i < timesToAdd; i++) {
-            executor.execute(() -> {
-                try {
-                    this.controller.addTopic(topic1);
-                    timesAdded.incrementAndGet();
-                } catch (InterruptedException ignored) {
-                }
-            });
-        }
-        executor.shutdown();
-        executor.awaitTermination(500, TimeUnit.MILLISECONDS);
-        assertEquals(timesToAdd, timesAdded.get());
-    }
-
-    @Test
-    public void addTopicFalseTest() throws InterruptedException {
-        this.controller.start();
-        String topic1 = "topic1";
-        boolean added = this.controller.addTopic(topic1);
-        assertEquals(true, added);
-        added = this.controller.addTopic(topic1);
-        assertEquals(false, added);
-    }
-
-    @Test
-    public void removeAddedTopicTest() throws InterruptedException {
-        this.controller.start();
-        String topic1 = "topic1";
-        this.controller.addTopic(topic1);
-        boolean removed = this.controller.removeTopic(topic1);
-        assertEquals(true, removed);
-    }
-
-    @Test
-    public void removeNotAddedTopicTest() throws InterruptedException {
-        this.controller.start();
-        String topic1 = "topic1";
-        boolean removed = this.controller.removeTopic(topic1);
-        assertEquals(false, removed);
     }
 
     @Test
@@ -122,46 +67,12 @@ public class KafkaControllerTests {
 
     @Test
     public void firstSubscribeAndPollingTest() throws InterruptedException {
-        String topic1 = "topic1";
         ConsumerRecords records = mock(ConsumerRecords.class);
         when(kafkaConsumer.poll(anyLong())).thenReturn(records);
         this.controller.start();
-        this.controller.addTopic(topic1);
         verify(kafkaConsumer, timeout(200).times(1)).subscribe(subscribeCaptor.capture(), any());
         //verify that the control loop is polling repeatedly.  Normally there would be a delay but
         //the kafkaConsumer has been mocked to return immediatly on poll
-        verify(kafkaConsumer, timeout(200).atLeast(5)).poll((anyLong()));
-        assertEquals(1, subscribeCaptor.getValue().size());
-        assertTrue(subscribeCaptor.getValue().contains(topic1));
-        this.controller.stop(10, TimeUnit.MILLISECONDS);
-    }
-
-    /**
-     * Tests that a topic can be added and subscribed, then removed and unsubscribed, then added again and the controller
-     * still functions
-     */
-    @Test
-    public void addRemoveAddTest() throws InterruptedException {
-        String topic1 = "topic1";
-        ConsumerRecords records = mock(ConsumerRecords.class);
-        when(kafkaConsumer.poll(anyLong())).thenReturn(records);
-        this.controller.start();
-        this.controller.addTopic(topic1);
-        verify(kafkaConsumer, timeout(200).times(1)).subscribe(subscribeCaptor.capture(), any());
-        //verify that the control loop is polling repeatedly.  Normally there would be a delay but
-        //the kafkaConsumer has been mocked to return immediatly on poll
-        verify(kafkaConsumer, timeout(200).atLeast(5)).poll((anyLong()));
-        assertEquals(1, subscribeCaptor.getValue().size());
-        assertTrue(subscribeCaptor.getValue().contains(topic1));
-        //remove the topic
-        reset(kafkaConsumer);
-        this.controller.removeTopic(topic1);
-        verify(kafkaConsumer, timeout(200).times(1)).subscribe(subscribeCaptor.capture(), any());
-        assertEquals(0, subscribeCaptor.getValue().size());
-        //add the topic back
-        reset(kafkaConsumer);
-        this.controller.addTopic(topic1);
-        verify(kafkaConsumer, timeout(200).times(1)).subscribe(subscribeCaptor.capture(), any());
         verify(kafkaConsumer, timeout(200).atLeast(5)).poll((anyLong()));
         assertEquals(1, subscribeCaptor.getValue().size());
         assertTrue(subscribeCaptor.getValue().contains(topic1));

--- a/connectors/kafka/src/test/java/forklift/connectors/KafkaControllerTests.java
+++ b/connectors/kafka/src/test/java/forklift/connectors/KafkaControllerTests.java
@@ -6,6 +6,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -52,14 +53,27 @@ public class KafkaControllerTests {
     }
 
     @Test
-    public void addTopicTrueTest() {
+    public void addTopicTrueTest() throws InterruptedException {
+        this.controller.start();
         String topic1 = "topic1";
         boolean added = this.controller.addTopic(topic1);
         assertEquals(true, added);
     }
 
     @Test
-    public void addTopicFalseTest() {
+    public void addingTheSameTopicRepeatedlyDoesntLock() throws InterruptedException {
+
+        this.controller.start();
+        String topic1 = "topic1";
+        for(int i = 0; i < 10; i++){
+            this.controller.addTopic(topic1);
+        }
+        assertTrue(true);
+    }
+
+    @Test
+    public void addTopicFalseTest() throws InterruptedException  {
+        this.controller.start();
         String topic1 = "topic1";
         boolean added = this.controller.addTopic(topic1);
         assertEquals(true, added);
@@ -68,7 +82,8 @@ public class KafkaControllerTests {
     }
 
     @Test
-    public void removeAddedTopicTest() {
+    public void removeAddedTopicTest() throws InterruptedException  {
+        this.controller.start();
         String topic1 = "topic1";
         this.controller.addTopic(topic1);
         boolean removed = this.controller.removeTopic(topic1);
@@ -76,7 +91,8 @@ public class KafkaControllerTests {
     }
 
     @Test
-    public void removeNotAddedTopicTest() {
+    public void removeNotAddedTopicTest() throws InterruptedException  {
+        this.controller.start();
         String topic1 = "topic1";
         boolean removed = this.controller.removeTopic(topic1);
         assertEquals(false, removed);
@@ -124,16 +140,18 @@ public class KafkaControllerTests {
         assertEquals(1, subscribeCaptor.getValue().size());
         assertTrue(subscribeCaptor.getValue().contains(topic1));
         //remove the topic
+        reset(kafkaConsumer);
         this.controller.removeTopic(topic1);
         verify(kafkaConsumer, timeout(200).times(1)).subscribe(subscribeCaptor.capture(), any());
         assertEquals(0, subscribeCaptor.getValue().size());
-        this.controller.stop(10, TimeUnit.MILLISECONDS);
         //add the topic back
+        reset(kafkaConsumer);
         this.controller.addTopic(topic1);
         verify(kafkaConsumer, timeout(200).times(1)).subscribe(subscribeCaptor.capture(), any());
         verify(kafkaConsumer, timeout(200).atLeast(5)).poll((anyLong()));
         assertEquals(1, subscribeCaptor.getValue().size());
         assertTrue(subscribeCaptor.getValue().contains(topic1));
+        this.controller.stop(10, TimeUnit.MILLISECONDS);
     }
 
     private ConsumerRecord<?, ?> generateRecord(String topic, int partition, String value, long offset) {

--- a/connectors/kafka/src/test/java/forklift/connectors/KafkaControllerTests.java
+++ b/connectors/kafka/src/test/java/forklift/connectors/KafkaControllerTests.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -24,10 +23,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.util.Collection;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Created by afrieze on 3/3/17.

--- a/connectors/kafka/src/test/java/forklift/consumer/KafkaTopicConsumerTests.java
+++ b/connectors/kafka/src/test/java/forklift/consumer/KafkaTopicConsumerTests.java
@@ -51,16 +51,4 @@ public class KafkaTopicConsumerTests {
         when(this.controller.isRunning()).thenReturn(false);
         consumer.receive(100);
     }
-
-    @Test
-    public void addTopicTest() throws ConnectorException, InterruptedException {
-        consumer.receive(100);
-        verify(controller).addTopic(this.topic);
-    }
-
-    @Test
-    public void closeAndRemoveTopicTest() throws ConnectorException, InterruptedException {
-        consumer.close();
-        verify(controller).removeTopic(this.topic);
-    }
 }

--- a/connectors/kafka/src/test/java/forklift/consumer/KafkaTopicConsumerTests.java
+++ b/connectors/kafka/src/test/java/forklift/consumer/KafkaTopicConsumerTests.java
@@ -53,13 +53,13 @@ public class KafkaTopicConsumerTests {
     }
 
     @Test
-    public void addTopicTest() throws ConnectorException {
+    public void addTopicTest() throws ConnectorException, InterruptedException {
         consumer.receive(100);
         verify(controller).addTopic(this.topic);
     }
 
     @Test
-    public void closeAndRemoveTopicTest() throws ConnectorException {
+    public void closeAndRemoveTopicTest() throws ConnectorException, InterruptedException {
         consumer.close();
         verify(controller).removeTopic(this.topic);
     }

--- a/connectors/kafka/src/test/java/forklift/integration/ConsumerActionTests.java
+++ b/connectors/kafka/src/test/java/forklift/integration/ConsumerActionTests.java
@@ -1,0 +1,42 @@
+package forklift.integration;
+
+import forklift.Forklift;
+import forklift.connectors.ConnectorException;
+import forklift.consumer.Consumer;
+import forklift.exception.StartupException;
+import forklift.producers.ForkliftProducerI;
+import forklift.producers.ProducerException;
+import org.junit.Test;
+
+public class ConsumerActionTests extends BaseIntegrationTest {
+
+    /**
+     * Test subscribing to a topic, unsubscribing, then resubscribing to the topic.
+     */
+    @Test
+    public void topicTurnoverTest() throws StartupException, ConnectorException, InterruptedException, ProducerException {
+
+        String topic = "forklift-string-topic";
+        Forklift forklift = serviceManager.newManagedForkliftInstance();
+        ForkliftProducerI producer = forklift.getConnector().getQueueProducer("forklift-string-topic");
+        sentMessageIds.add(producer.send("message1"));
+        final Consumer c1 = new Consumer(StringConsumer.class, forklift);
+        // Shutdown the consumer after all the messages have been processed.
+        c1.setOutOfMessages((listener) -> {
+            listener.shutdown();
+        });
+        // Start the consumer.
+        c1.listen();
+        Thread.sleep(3000);
+        sentMessageIds.add(producer.send("message2"));
+        final Consumer c2 = new Consumer(StringConsumer.class, forklift);
+        // Shutdown the consumer after all the messages have been processed.
+        c2.setOutOfMessages((listener) -> {
+            listener.shutdown();
+        });
+        // Start the consumer.
+        c2.listen();
+        messageAsserts();
+    }
+
+}

--- a/connectors/kafka/src/test/java/forklift/integration/ConsumerActionTests.java
+++ b/connectors/kafka/src/test/java/forklift/integration/ConsumerActionTests.java
@@ -15,8 +15,6 @@ public class ConsumerActionTests extends BaseIntegrationTest {
      */
     @Test
     public void topicTurnoverTest() throws StartupException, ConnectorException, InterruptedException, ProducerException {
-
-        String topic = "forklift-string-topic";
         Forklift forklift = serviceManager.newManagedForkliftInstance();
         ForkliftProducerI producer = forklift.getConnector().getQueueProducer("forklift-string-topic");
         sentMessageIds.add(producer.send("message1"));

--- a/connectors/kafka/src/test/java/forklift/integration/RebalanceTests.java
+++ b/connectors/kafka/src/test/java/forklift/integration/RebalanceTests.java
@@ -18,7 +18,7 @@ import java.util.concurrent.Executors;
  * Tests which focus on causing partitions to be rebalanced.
  */
 public class RebalanceTests extends BaseIntegrationTest {
-
+    
     @Test
     public void testRebalanceUnderLoad() throws InterruptedException {
         ExecutorService executor = Executors.newFixedThreadPool(35);
@@ -70,7 +70,7 @@ public class RebalanceTests extends BaseIntegrationTest {
         server6.stopProducers();
         server7.stopProducers();
         //wait to finish any processing
-        for (int i = 0; i < 60 && consumedMessageIds.size() != sentMessageIds.size(); i++) {
+        for (int i = 0; i < 30 && consumedMessageIds.size() != sentMessageIds.size(); i++) {
             log.info("Waiting: " + i);
             Thread.sleep(1000);
         }
@@ -153,7 +153,7 @@ public class RebalanceTests extends BaseIntegrationTest {
 
         server10.stopProducers();
         //wait to finish any processing
-        for (int i = 0; i < 60 && consumedMessageIds.size() != sentMessageIds.size(); i++) {
+        for (int i = 0; i < 30 && consumedMessageIds.size() != sentMessageIds.size(); i++) {
             log.info("Waiting: " + i);
             Thread.sleep(1000);
         }

--- a/connectors/kafka/src/test/java/forklift/integration/RebalanceTests.java
+++ b/connectors/kafka/src/test/java/forklift/integration/RebalanceTests.java
@@ -6,6 +6,7 @@ import forklift.consumer.Consumer;
 import forklift.exception.StartupException;
 import forklift.producers.ForkliftProducerI;
 import org.junit.Test;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -18,7 +19,7 @@ import java.util.concurrent.Executors;
  * Tests which focus on causing partitions to be rebalanced.
  */
 public class RebalanceTests extends BaseIntegrationTest {
-    
+
     @Test
     public void testRebalanceUnderLoad() throws InterruptedException {
         ExecutorService executor = Executors.newFixedThreadPool(35);


### PR DESCRIPTION
*Overview*
Bridger discovered that calls to subscribe reset the fetch positions of topics.  Additionally, there are some concerns that the topic partitions assigned for topics which do not change from subscription to subscription may be modified if the subscription occurs during some form of rebalance event.  Although it should be possible to keep the existing approach, it was much simpler to simply move to a controller per topic setup.  We may wish to re-visit this in the future should performance become an issue.
