### PR TITLE
Switch to ES REST client for Replay Messages

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -10,6 +10,9 @@ link:doc/forklift.adoc[Documentation]
 == Releases
 link:doc/prev_releases.adoc[Previous Releases]
 
+* *December 2nd 2017* - v3.0
+** Upgrade replay logging to utilize Elastic Search 5
+
 * *Novemeber 28th 2017* - v2.3
 ** Update build to automate releases to sonatype
 ** Align release numbers of subcomponents to avoid having a version 1 of a plugin while a version 2 of the core is being used.

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val baseSettings = Seq(
   organization := "com.github.dcshock",
-  version := "2.3",
+  version := "3.0",
   scalaVersion := "2.11.7",
   javacOptions ++= Seq("-source", "1.8"),
   javacOptions in compile ++= Seq("-g:lines,vars,source", "-deprecation"),

--- a/plugins/replay/build.sbt
+++ b/plugins/replay/build.sbt
@@ -1,7 +1,8 @@
 name := "forklift-replay"
 
 libraryDependencies ++= Seq(
-  "org.elasticsearch" % "elasticsearch" % "2.4.1",
+  "org.elasticsearch" % "elasticsearch" % "2.4.1", // retained for now, to support embedded ES clusters
+  "org.elasticsearch.client" % "rest" % "5.0.2",
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.7.3",
   "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.7.3"
 )

--- a/plugins/replay/src/main/java/forklift/replay/ReplayES.java
+++ b/plugins/replay/src/main/java/forklift/replay/ReplayES.java
@@ -49,7 +49,7 @@ public class ReplayES {
     private final Consumer consumer;
 
     /**
-     * Constructs a new ReplayES instance using the default transport port (9200) for
+     * Constructs a new ReplayES instance using the default REST port (9200) for
      * sending messages to elasticsearch.
      *
      * @param clientOnly whether the plugin is only an elasticsearch client, or an
@@ -57,6 +57,8 @@ public class ReplayES {
      * @param hostname the address of the ES host to send messages to
      * @param clusterName the name of the elasticsearch cluster to send logs to
      * @param connector the connector to use for queuing messages
+     *
+     * @deprecated use {@link #ReplayES(boolean, String, ForkliftConnectorI)} instead
      */
     public ReplayES(boolean clientOnly, String hostname, String clusterName, ForkliftConnectorI connector) {
         this(clientOnly, hostname, 9200, clusterName, connector);
@@ -72,8 +74,38 @@ public class ReplayES {
      * @param port the port number of the ES transport port for the given host
      * @param clusterName the name of the elasticsearch cluster to send logs to
      * @param connector the connector to use for queuing messages
+     *
+     * @deprecated use {@link #ReplayES(boolean, String, int, ForkliftConnectorI)} instead
      */
     public ReplayES(boolean clientOnly, String hostname, int port, String clusterName, ForkliftConnectorI connector) {
+        this(clientOnly, hostname, port, connector);
+    }
+
+    /**
+     * Constructs a new ReplayES instance using the default REST port (9200) for
+     * sending messages to elasticsearch.
+     *
+     * @param clientOnly whether the plugin is only an elasticsearch client, or an
+     *     embedded elasticsearch node should be started
+     * @param hostname the address of the ES host to send messages to
+     * @param connector the connector to use for queuing messages
+     */
+    public ReplayES(boolean clientOnly, String hostname, ForkliftConnectorI connector) {
+        this(clientOnly, hostname, 9200, connector);
+    }
+
+
+    /**
+     * Constructs a new ReplayES instance sending messages to elasticsearch based
+     * on the given parameters.
+     *
+     * @param clientOnly whether the plugin is only an elasticsearch client, or an
+     *     embedded elasticsearch node should be started
+     * @param hostname the address of the ES host to send messages to
+     * @param port the port number of the ES transport port for the given host
+     * @param connector the connector to use for queuing messages
+     */
+    public ReplayES(boolean clientOnly, String hostname, int port, ForkliftConnectorI connector) {
         /*
          * Setup the connection to the server. If we are only a client we'll not setup a node locally to run.
          * This will help developers and smaller setups avoid the pain of setting up elastic search.
@@ -96,7 +128,7 @@ public class ReplayES {
             }
         }
 
-        this.writer = new ReplayESWriter(hostname, port, clusterName);
+        this.writer = new ReplayESWriter(hostname, port);
         this.writer.start();
 
         Runtime.getRuntime().addShutdownHook(new Thread() {
@@ -144,7 +176,7 @@ public class ReplayES {
         } catch (InterruptedException ignored) {
         }
 
-        this.writer.shutdown();
+        this.writer.close();
     }
 
     @LifeCycle(value=ProcessStep.Pending, annotation=Replay.class)

--- a/plugins/replay/src/main/java/forklift/replay/ReplayESWriter.java
+++ b/plugins/replay/src/main/java/forklift/replay/ReplayESWriter.java
@@ -150,6 +150,14 @@ public class ReplayESWriter extends ReplayStoreThread<ReplayESWriterMsg> {
         final String endpoint = "/" + index + "/log/" + id;
         try {
             restClient.performRequest("DELETE", endpoint);
+        } catch (ResponseException e) {
+            // sometimes we might try to delete something that was already deleted by something else;
+            // in which case there is no error
+            if (e.getResponse().getStatusLine().getStatusCode() == HttpStatus.SC_NOT_FOUND) {
+                return;
+            }
+
+            log.error("Error deleting message with id {} for index {}", id, index,  e);
         } catch (IOException e) {
             log.error("Error deleting message with id {} for index {}", id, index,  e);
         }

--- a/plugins/replay/src/main/java/forklift/replay/ReplayESWriter.java
+++ b/plugins/replay/src/main/java/forklift/replay/ReplayESWriter.java
@@ -1,94 +1,167 @@
 package forklift.replay;
 
-import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.client.transport.TransportClient;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.transport.InetSocketTransportAddress;
-import org.elasticsearch.index.VersionType;
-import org.elasticsearch.index.engine.VersionConflictEngineException;
-import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.search.SearchHit;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpStatus;
+import org.apache.http.entity.ContentType;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.nio.entity.NStringEntity;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.InetSocketAddress;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 
 public class ReplayESWriter extends ReplayStoreThread<ReplayESWriterMsg> {
     private static final Logger log = LoggerFactory.getLogger(ReplayES.class);
+    private static final ObjectMapper mapper = new ObjectMapper();
 
-    private final TransportClient client;
+    private final RestClient restClient;
 
     public ReplayESWriter(String hostname) {
-        this(hostname, 9300, "elasticsearch");
+        this(hostname, 9200, "elasticsearch");
     }
 
+    // clusterName is retained in constructor for compatibility
     public ReplayESWriter(String hostname, int port, String clusterName) {
-        final Settings settings = Settings.settingsBuilder()
-                        .put("cluster.name", clusterName).build();
-
-        this.client = TransportClient.builder()
-            .settings(settings)
-            .build()
-            .addTransportAddress(new InetSocketTransportAddress(new InetSocketAddress(hostname, port)));
+        this.restClient = RestClient.builder(new HttpHost(hostname, port, "http"))
+            .setRequestConfigCallback(requestConfig -> requestConfig
+                                                           .setConnectTimeout(3_000)
+                                                           .setSocketTimeout(20_000))
+            .setDefaultHeaders(new Header[] {
+                 new BasicHeader("Accept", "application/json; charset=utf-8"),
+                 new BasicHeader("Content-Type", "application/json; charset=utf-8")
+             })
+            .setMaxRetryTimeoutMillis(20_000)
+            .build();
     }
 
     @Override
-    protected void poll(ReplayESWriterMsg t) {
-        final String replayVersion = t.getFields().get("forklift-replay-version");
+    protected void poll(ReplayESWriterMsg replayMessage) {
+        final String replayVersion = replayMessage.getFields().get("forklift-replay-version");
         if ("3".equals(replayVersion)) { // latest version
-            String indexDate = t.getFields().get("first-processed-date");
-            if (indexDate == null)
-                indexDate = LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE);
-            final String index = "forklift-replay-" + indexDate;
-
-            try {
-                // Index the new information.
-                client.prepareIndex(index, "log")
-                    .setVersion(t.getVersion()).setVersionType(VersionType.EXTERNAL_GTE)
-                    .setId(t.getId()).setSource(t.getFields()).execute().actionGet();
-            } catch (VersionConflictEngineException expected) {
-                log.debug("Newer replay message already exists", expected);
-            }
+            processVersion3Replay(replayMessage);
         } else if ("2".equals(replayVersion) || replayVersion == null) { // older versions didn't have the replay version or didn't persist it with the message
-            final String index = "forklift-replay-" + LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE);
-
-            // In order to ensure there is only one replay msg for a given id we have to clean the msg id from
-            // any previously created indexes.
-            try {
-                final SearchResponse resp = client.prepareSearch("forklift-replay*").setTypes("log")
-                    .setQuery(QueryBuilders.termQuery("_id", t.getId()))
-                    .setFrom(0).setSize(50).setExplain(false)
-                    .execute()
-                    .actionGet();
-
-                if (resp != null && resp.getHits() != null && resp.getHits().getHits() != null) {
-                    for (SearchHit hit : resp.getHits().getHits()) {
-                        if (!hit.getIndex().equals(index))
-                            client.prepareDelete(hit.getIndex(), "log", t.getId()).execute().actionGet();
-                    }
-                }
-            } catch (Exception e) {
-                log.error("", e);
-                log.error("Unable to search for old replay logs {}", t.getId());
-            }
-
-            try {
-                // Index the new information.
-                client.prepareIndex(index, "log")
-                    .setVersion(t.getVersion()).setVersionType(VersionType.EXTERNAL_GTE)
-                    .setId(t.getId()).setSource(t.getFields()).execute().actionGet();
-            } catch (VersionConflictEngineException expected) {
-                log.debug("Newer replay message already exists", expected);
-            }
+            processVersion2OrEarlierReplay(replayMessage);
         } else {
-            log.error("Unrecognized replay version: '{}' for message ID '{}' with fields '{}' ", replayVersion, t.getId(), t.getFields());
+            log.error("Unrecognized replay version: '{}' for message ID '{}' with fields '{}'",
+                      replayVersion, replayMessage.getId(), replayMessage.getFields());
+        }
+    }
+
+    private void processVersion3Replay(final ReplayESWriterMsg replayMessage) {
+        String indexDate = replayMessage.getFields().get("first-processed-date");
+        if (indexDate == null) {
+            indexDate = LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE);
+        }
+        final String index = "forklift-replay-" + indexDate;
+
+        indexReplayMessage(replayMessage, index);
+    }
+
+    private void processVersion2OrEarlierReplay(ReplayESWriterMsg replayMessage) {
+        final String index = "forklift-replay-" + LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE);
+
+        for (String existingMessageIndex : searchForIndexesWithId(replayMessage.getId())) {
+            if (!existingMessageIndex.equals(index)) {
+                deleteMessageInIndex(replayMessage.getId(), existingMessageIndex);
+            }
+        }
+
+        indexReplayMessage(replayMessage, index);
+    }
+
+    private void indexReplayMessage(final ReplayESWriterMsg replayMessage, final String index) {
+        final String id = replayMessage.getId();
+        final String endpoint =  "/" + index + "/log/" +  id;
+
+        final Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("version_type", "external_gte");
+        queryParams.put("version", "" + replayMessage.getVersion());
+
+        final HttpEntity entity;
+        try {
+            final String entityContents = mapper.writeValueAsString(replayMessage.getFields());
+            entity = new NStringEntity(entityContents, ContentType.APPLICATION_JSON);
+        } catch (JsonProcessingException e) {
+            log.error("Could not write replay fields to JSON: (id {}, fields {})", replayMessage.getId(), replayMessage.getFields(), e);
+            return;
+        }
+
+        try {
+            restClient.performRequest("PUT", endpoint, queryParams, entity);
+        } catch (ResponseException e) {
+            // conflicts are normal when versioned index requests are submitted in the wrong order
+            if (e.getResponse().getStatusLine().getStatusCode() == HttpStatus.SC_CONFLICT) {
+                return;
+            }
+
+            log.error("Error indexing replay message (id {}, fields {})", id, replayMessage.getFields(), e);
+        } catch (IOException e) {
+            log.error("Error indexing replay message (id {}, fields {})", id, replayMessage.getFields(), e);
+        }
+    }
+
+    private Iterable<String> searchForIndexesWithId(final String id) {
+        final String endpoint = "/forklift-replay*/_search";
+        final Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("q", "_id:" + id);
+        queryParams.put("size", "50");
+
+        try {
+            final Response response = restClient.performRequest("GET", endpoint, queryParams);
+            try {
+                final JsonNode jsonResponse = mapper.readTree(response.getEntity().getContent());
+                final JsonNode hits = jsonResponse.get("hits").get("hits");
+                final List<String> indexes = new ArrayList<>();
+
+                for (final JsonNode hit : hits) {
+                    final String hitIndex = hit.get("_index").asText();
+                    indexes.add(hitIndex);
+                }
+
+                return indexes;
+            } catch (Exception e) {
+                log.error("Error parsing elasticsearch response to search for id {}", id, e);
+            }
+        } catch (IOException e) {
+            log.error("Error searching for indexes for id {}", id,  e);
+        }
+
+        return Collections.emptyList();
+    }
+
+    private void deleteMessageInIndex(final String id, final String index) {
+        final String endpoint = "/" + index + "/log/" + id;
+        try {
+            restClient.performRequest("DELETE", endpoint);
+        } catch (IOException e) {
+            log.error("Error deleting message with id {} for index {}", id, index,  e);
         }
     }
 
     public void shutdown() {
-        if (client != null)
-            client.close();
+        if (restClient != null) {
+            try {
+                restClient.close();
+            } catch (IOException e) {
+                log.error("Couldn't shutdown Elasticsearch REST client", e);
+            }
+        }
     }
 }

--- a/server/src/main/java/forklift/ForkliftServer.java
+++ b/server/src/main/java/forklift/ForkliftServer.java
@@ -16,7 +16,6 @@ import forklift.retry.RetryES;
 import forklift.retry.RetryHandler;
 import forklift.stats.StatsCollector;
 import org.apache.activemq.broker.BrokerService;
-import org.apache.http.annotation.ThreadSafe;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -41,7 +40,6 @@ import java.util.concurrent.CountDownLatch;
  *
  * @author zdavep
  */
-@ThreadSafe
 public final class ForkliftServer {
 
     private ExecutorService executor = Executors.newSingleThreadExecutor();


### PR DESCRIPTION
#### Changes:
- Switch from ElasticSearch Transport client to a REST client (a directly REST client, as recommended by elasticsearch)

#### Testing:
- Tested running non-erroring messages, without a "replay-version" set in the replay message, delete messages with the same ID in another `forklift-replay*` index and then index a new document in the proper index (ES 2.4 and 5.5).
- Tested ~100 non-erroring messages processing with the latest `replay-version` and observed that they all end up with the final state of `Complete` (ES 2.4 and 5.5)

#### Old Testing:
- Tested that when there is an error, replay messages still end up in an error state (without the version change, out-of-order messages would overwrite final states)
- Tested that the records indexed on the previous day are properly deleted

---

There were some cantankerous connection issues observed when using the ES Transport client when elasticsearch would error and then come back. There have been a few proposed solutions, but since the same problems don't seem to be happening for the REST client, this seems like the most direct solution.

In addition, @arbiter34 pointed out that [support for the transport client is being phased out of ElasticSearch](http://www.elastic.co/blog/state-of-the-official-elasticsearch-java-clients).

Here's one of the alternative approaches I coded up earlier (but hasn't been tested): https://github.com/dcshock/forklift/compare/replay-server-recovery