### PR TITLE
Make core thread pool size unbounded

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -10,6 +10,9 @@ link:doc/forklift.adoc[Documentation]
 == Releases
 link:doc/prev_releases.adoc[Previous Releases]
 
+* *August 31st 2017* - v2.1
+** Removed limit on the size of the core thread pool for consumer polling threads
+
 * *June 2nd 2017* - v2.0
 ** Moved core source annotations from the "forklift.decorators" package to "forklift.source.decorators"
 ** Added RoleInput and GroupedTopic sources

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -2,7 +2,7 @@ organization := "com.github.dcshock"
 
 name := "forklift"
 
-version := "2.0"
+version := "2.1"
 
 javacOptions ++= Seq("-source", "1.8")
 

--- a/core/src/main/java/forklift/concurrent/Executors.java
+++ b/core/src/main/java/forklift/concurrent/Executors.java
@@ -37,11 +37,11 @@ public final class Executors {
     }
 
     /**
-     * A core thread pool factory method that returns a "better" alternative to a cached thread pool.
+     * A core thread pool factory method that returns a cached thread pool.
      */
     public static ExecutorService newCoreThreadPool(final String name) {
         final ThreadPoolExecutor pool = new ThreadPoolExecutor(
-            (2 * cpus),  (6 * cpus), 60, TimeUnit.SECONDS, new SynchronousQueue<Runnable>(), daemonThreadFactory(name)
+            (2 * cpus),  Integer.MAX_VALUE, 60, TimeUnit.SECONDS, new SynchronousQueue<Runnable>(), daemonThreadFactory(name)
         );
         pool.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
         return pool;


### PR DESCRIPTION
#### Changes:
- Make core thread pool have an unbounded maximum number of threads (essentially a cached thread pool)

We've recently ran into the core thread limit in our project, making it hard to use additional consumers. Since the number of core threads is a static compile-time configuration, it should be fine to make the core thread pool unbounded.

---
Please Review: @dcshock @dthompsn @zdavep @seanmrogers