### PR TITLE
fix connector field name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.class
+tags
 
 # Package Files #
 *.jar

--- a/plugins/retry/build.sbt
+++ b/plugins/retry/build.sbt
@@ -2,7 +2,7 @@ organization := "com.github.dcshock"
 
 name := "forklift-retry"
 
-version := "2.0"
+version := "2.2"
 
 javacOptions ++= Seq("-source", "1.8")
 

--- a/plugins/retry/src/main/java/forklift/retry/RetryES.java
+++ b/plugins/retry/src/main/java/forklift/retry/RetryES.java
@@ -116,7 +116,7 @@ public class RetryES {
                         for (Hit<Map, Void> msg : results.getHits(Map.class)) {
                             try {
                                 final Map<String, String> fields = msg.source;
-                                final String msgConnector = fields.get("connectorName");
+                                final String msgConnector = fields.get("destination-connector");
 
                                 if (msgConnector != null &&
                                     !givenConnector.equals(msgConnector)) {

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -2,7 +2,7 @@ organization := "com.github.dcshock"
 
 name := "forklift-server"
 
-version := "2.1"
+version := "2.2"
 
 enablePlugins(JavaAppPackaging)
 
@@ -25,7 +25,7 @@ libraryDependencies ++= Seq(
   "com.github.dcshock" % "forklift"           % "2.1",
   "com.github.dcshock" % "forklift-activemq"  % "2.0",
   "com.github.dcshock" % "forklift-replay"    % "2.0",
-  "com.github.dcshock" % "forklift-retry"     % "2.0",
+  "com.github.dcshock" % "forklift-retry"     % "2.2",
   "com.github.dcshock" % "forklift-stats"     % "1.0",
   "com.github.dcshock" % "consul-rest-client" % "0.10",
   "org.apache.activemq" % "activemq-broker" % "5.14.0",


### PR DESCRIPTION
### Changes
* A field name was incorrect, causing retries to fail when searching for `connectorName` which should be `destination-connector`

### Testing
* created some retries for forklift to pick up, confirmed old version failed with `Unable to read result` and that the this version doesn't fail. 

### Please Review
@Kuroshii @dcshock @AFrieze 

Not sure how the versioning of this project works, let me know if I need to make changes. 