### PR TITLE
Optimize out Expensive ES Query in the Replay Plugin

### DIFF
--- a/plugins/replay/src/main/java/forklift/replay/ReplayESWriter.java
+++ b/plugins/replay/src/main/java/forklift/replay/ReplayESWriter.java
@@ -36,18 +36,54 @@ public class ReplayESWriter extends ReplayStoreThread<ReplayESWriterMsg> {
 
     @Override
     protected void poll(ReplayESWriterMsg t) {
-        String indexDate = t.getFields().get("first-processed-date");
-        if (indexDate == null)
-            indexDate = LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE);
-        final String index = "forklift-replay-" + indexDate;
+        final String replayVersion = t.getFields().get("forklift-replay-version");
+        if ("3".equals(replayVersion)) { // latest version
+            String indexDate = t.getFields().get("first-processed-date");
+            if (indexDate == null)
+                indexDate = LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE);
+            final String index = "forklift-replay-" + indexDate;
 
-        try {
-            // Index the new information.
-            client.prepareIndex(index, "log")
-                .setVersion(t.getVersion()).setVersionType(VersionType.EXTERNAL_GTE)
-                .setId(t.getId()).setSource(t.getFields()).execute().actionGet();
-        } catch (VersionConflictEngineException expected) {
-            log.debug("Newer replay message already exists", expected);
+            try {
+                // Index the new information.
+                client.prepareIndex(index, "log")
+                    .setVersion(t.getVersion()).setVersionType(VersionType.EXTERNAL_GTE)
+                    .setId(t.getId()).setSource(t.getFields()).execute().actionGet();
+            } catch (VersionConflictEngineException expected) {
+                log.debug("Newer replay message already exists", expected);
+            }
+        } else if ("2".equals(replayVersion) || replayVersion == null) { // older versions didn't have the replay version or didn't persist it with the message
+            final String index = "forklift-replay-" + LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE);
+
+            // In order to ensure there is only one replay msg for a given id we have to clean the msg id from
+            // any previously created indexes.
+            try {
+                final SearchResponse resp = client.prepareSearch("forklift-replay*").setTypes("log")
+                    .setQuery(QueryBuilders.termQuery("_id", t.getId()))
+                    .setFrom(0).setSize(50).setExplain(false)
+                    .execute()
+                    .actionGet();
+
+                if (resp != null && resp.getHits() != null && resp.getHits().getHits() != null) {
+                    for (SearchHit hit : resp.getHits().getHits()) {
+                        if (!hit.getIndex().equals(index))
+                            client.prepareDelete(hit.getIndex(), "log", t.getId()).execute().actionGet();
+                    }
+                }
+            } catch (Exception e) {
+                log.error("", e);
+                log.error("Unable to search for old replay logs {}", t.getId());
+            }
+
+            try {
+                // Index the new information.
+                client.prepareIndex(index, "log")
+                    .setVersion(t.getVersion()).setVersionType(VersionType.EXTERNAL_GTE)
+                    .setId(t.getId()).setSource(t.getFields()).execute().actionGet();
+            } catch (VersionConflictEngineException expected) {
+                log.debug("Newer replay message already exists", expected);
+            }
+        } else {
+            log.error("Unrecognized replay version: '{}' for message ID '{}' with fields '{}' ", replayVersion, t.getId(), t.getFields());
         }
     }
 

--- a/plugins/replay/src/main/java/forklift/replay/ReplayLogBuilder.java
+++ b/plugins/replay/src/main/java/forklift/replay/ReplayLogBuilder.java
@@ -66,6 +66,10 @@ public class ReplayLogBuilder {
         // carry a description of the original source across restarts
         props.putIfAbsent("source-description", sourceDescription);
 
+
+        if (!props.containsKey("forklift-replay-step-count")) { // new messages are version 3
+            props.putIfAbsent("forklift-replay-version", "3");
+        }
         final long stepCount = Integer.parseInt(props.getOrDefault("forklift-replay-step-count", "0")) + 1;
         props.put("forklift-replay-step-count", "" + stepCount);
         props.putIfAbsent("first-processed-date", LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE));
@@ -82,7 +86,6 @@ public class ReplayLogBuilder {
         fields.put("step", step.toString());
         errors.ifPresent(errorString -> fields.put("errors", errorString));
         fields.put("time", LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
-        fields.put("forklift-replay-version", "2");
 
         // message-level details
         fields.put("text", msg.getMsg());

--- a/plugins/replay/src/main/java/forklift/replay/ReplayLogBuilder.java
+++ b/plugins/replay/src/main/java/forklift/replay/ReplayLogBuilder.java
@@ -13,6 +13,7 @@ import forklift.source.sources.TopicSource;
 import forklift.source.sources.QueueSource;
 import forklift.source.sources.RoleInputSource;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
@@ -67,6 +68,7 @@ public class ReplayLogBuilder {
 
         final long stepCount = Integer.parseInt(props.getOrDefault("forklift-replay-step-count", "0")) + 1;
         props.put("forklift-replay-step-count", "" + stepCount);
+        props.putIfAbsent("first-processed-date", LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE));
 
         // Map in properties
         for (String key : msg.getProperties().keySet()) {


### PR DESCRIPTION
#### Changes
- Add a `first-processed-date` property that persists with messages
- Use that `first-processed-date` property to determine the index for a message; no need to do any deleting since elasticsearch's versioning feature provides reliable upserts for us.

For the most part, messages never leave the index they start in, so this helps optimize for that case - after all, dealing with that unconditionally is very excessive. If we really think it's important to move a message to another index when it's reprocessed, I'd recommend moving that kind of logic to forklift-gui.

### Testing

Ran messages through consumers and observed that the `first-processed-date` property was present in the role message. I changed my local date and retried a message that ended in an errored state and observed that it stayed in the same index. 

Performed the same actions on the previous version of the replay plugin and observed that errored messages were written to the index corresponding to the current date.

### Backward Compatibility

_This is based on some observations from testing._

~~Since messages that are written before the change will not be deleted from their original index and then written to a new "permanent" index when retried, error replay logs that were written with the old version of replay will not be automatically fixed when they are retried, regardless of the success of the message.~~

~~Two easy solutions to this:~~
- ~~If the duplicate logs are unacceptable or inconvenient, deal with any errors before making this change to the replay plugin.~~
- ~~Accept that minor inconvenience and manually fix messages after retrying them. If this is the approach, it should be communicated to avoid accidentally duplicating messages.~~

---

Please Review: @dcshock @AFrieze @seanmrogers