### PR TITLE
Upgrade Kafka Dependencies to 0.11

### DIFF
--- a/connectors/kafka/build.sbt
+++ b/connectors/kafka/build.sbt
@@ -3,7 +3,7 @@ name := "forklift-kafka"
 libraryDependencies ++= Seq(
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.7.3",
   "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % "2.7.3",
-  "org.apache.kafka" % "kafka-clients" % "0.10.1.1-cp1" exclude("org.slf4j","slf4j-log4j12"),
+  "org.apache.kafka" % "kafka-clients" % "0.11.0.2" exclude("org.slf4j","slf4j-log4j12"),
   "io.confluent" % "kafka-avro-serializer" % "3.1.1" exclude("org.slf4j","slf4j-log4j12"),
   "org.apache.avro" % "avro" % "1.8.1"
 )
@@ -13,7 +13,8 @@ lazy val testDependencies = Seq(
   "com.novocode" % "junit-interface" % "0.11",
   "commons-net" % "commons-net" % "3.6",
   "org.mockito"       % "mockito-core"            % "1.9.5",
-  "io.confluent" % "kafka-schema-registry" % "3.1.1" exclude("org.slf4j","slf4j-log4j12"),
+  "io.confluent" % "kafka-schema-registry" % "3.3.1" exclude("org.slf4j","slf4j-log4j12"),
+  "org.apache.kafka" %% "kafka" % "0.11.0.2" exclude("org.slf4j","slf4j-log4j12"),
   "org.apache.zookeeper" % "zookeeper" % "3.4.9" exclude("org.slf4j","slf4j-log4j12"),
   //Added as it looks like the schema registry has a hard coded dependency on a log4j class that the bridge does not help with
   "log4j" % "log4j" % "1.2.14"

--- a/connectors/kafka/src/test/java/forklift/integration/ConsumerActionTests.java
+++ b/connectors/kafka/src/test/java/forklift/integration/ConsumerActionTests.java
@@ -19,18 +19,29 @@ public class ConsumerActionTests extends BaseIntegrationTest {
         ForkliftProducerI producer = forklift.getConnector().getQueueProducer("forklift-string-topic");
         sentMessageIds.add(producer.send("message1"));
         final Consumer c1 = new Consumer(StringConsumer.class, forklift);
+
         // Shutdown the consumer after all the messages have been processed.
         c1.setOutOfMessages((listener) -> {
-            listener.shutdown();
+            timeouts++;
+
+            if (sentMessageIds.equals(consumedMessageIds) || timeouts > maxTimeouts) {
+                listener.shutdown();
+            }
         });
         // Start the consumer.
         c1.listen();
-        Thread.sleep(3000);
+
         sentMessageIds.add(producer.send("message2"));
         final Consumer c2 = new Consumer(StringConsumer.class, forklift);
+
         // Shutdown the consumer after all the messages have been processed.
+        timeouts = 0;
         c2.setOutOfMessages((listener) -> {
-            listener.shutdown();
+            timeouts++;
+
+            if (sentMessageIds.equals(consumedMessageIds) || timeouts > maxTimeouts) {
+                listener.shutdown();
+            }
         });
         // Start the consumer.
         c2.listen();

--- a/connectors/kafka/src/test/java/forklift/integration/server/KafkaService.java
+++ b/connectors/kafka/src/test/java/forklift/integration/server/KafkaService.java
@@ -13,7 +13,7 @@ public class KafkaService implements Runnable {
 
     private KafkaServerStartable kafka;
 
-    public File dataDir = new File("src/test/resources/zafka");
+    public File dataDir = new File("target/kafka-test-data");
     private final int localZookeeperPort;
     private final int listenPort;
 
@@ -36,11 +36,13 @@ public class KafkaService implements Runnable {
         properties.setProperty("log.dirs", dataDir.getAbsolutePath());
         properties.setProperty("num.partitions", "16");
         properties.setProperty("num.recovery.threads.per.data.dir", "1");
+        properties.setProperty("offsets.topic.replication.factor", "1");
         properties.setProperty("log.retention.hours", "168");
         properties.setProperty("log.segment.bytes", "1073741824");
         properties.setProperty("log.retention.check.interval.ms", "300000");
         properties.setProperty("zookeeper.connect", "localhost:" + localZookeeperPort);
         properties.setProperty("zookeeper.connection.timeout.ms", "6000");
+
         KafkaConfig kafkaConfig = new KafkaConfig(properties);
         kafka = new KafkaServerStartable(kafkaConfig);
         kafka.startup();


### PR DESCRIPTION
#### Changes:
- Bump kafka versions
- Minor adjustments to test setup to act correctly for Kafka 0.11

There's a fairly big performance impact of using earlier clients when there's a later kafka version because of the cost of down-conversion, so this should generally improve or maintain the old consumer performance.

This should retain compatibility with most versions of Kafka, if I'm reading the [compatibility guide](https://cwiki.apache.org/confluence/display/KAFKA/Compatibility+Matrix) correctly.

----

Please Review: @seanmrogers @AFrieze @dcshock 