### PR TITLE
Fix Kafka Processing Errors

### DIFF
--- a/connectors/kafka/src/main/java/forklift/controller/AcknowledgedRecordHandler.java
+++ b/connectors/kafka/src/main/java/forklift/controller/AcknowledgedRecordHandler.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Supplier;
 
 /**
  * Maintains a batch of acknowledged records and provides management for adding and removing {@link org.apache.kafka.common.TopicPartition partitions}.
@@ -31,12 +32,20 @@ public class AcknowledgedRecordHandler {
      * blocking method and a short delay may occur should the available topic paritions be changing.
      *
      * @param record the record to acknowledge
+     * @param atomicCheck any check that needs to be performed atomicly with the acknowledgment
      * @return true if the record has been acknowledged and may be processed, else false
      * @throws InterruptedException if interrupted
      */
-    public boolean acknowledgeRecord(ConsumerRecord<?, ?> record) throws InterruptedException {
+    public boolean acknowledgeRecord(ConsumerRecord<?, ?> record, Supplier<Boolean> atomicCheck) throws InterruptedException {
         lock.readLock().lock();
         try {
+            if (atomicCheck != null) {
+                final Boolean checkResult = atomicCheck.get();
+                if (checkResult == null || !checkResult) {
+                    return false;
+                }
+            }
+
             TopicPartition topicPartition = new TopicPartition(record.topic(), record.partition());
             if (!assignment.contains(topicPartition)) {
                 return false;

--- a/connectors/kafka/src/main/java/forklift/controller/Generation.java
+++ b/connectors/kafka/src/main/java/forklift/controller/Generation.java
@@ -1,4 +1,4 @@
-package forklift.message;
+package forklift.controller;
 
 /** Represents the abstract time during which a record belonging to a dataset was acquired. */
 public class Generation {

--- a/connectors/kafka/src/main/java/forklift/controller/KafkaController.java
+++ b/connectors/kafka/src/main/java/forklift/controller/KafkaController.java
@@ -3,10 +3,10 @@ package forklift.controller;
 import forklift.message.KafkaMessage;
 import forklift.message.MessageStream;
 import forklift.message.ReadableMessageStream;
+import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.WakeupException;
@@ -40,14 +40,14 @@ public class KafkaController {
     private static final Logger log = LoggerFactory.getLogger(KafkaController.class);
     private volatile boolean running = false;
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
-    private final KafkaConsumer<?, ?> kafkaConsumer;
+    private final Consumer<?, ?> kafkaConsumer;
     private final MessageStream messageStream;
     private final String topic;
     private AcknowledgedRecordHandler acknowledgmentHandler = new AcknowledgedRecordHandler();
     private Map<TopicPartition, OffsetAndMetadata> failedOffset = null;
     private Map<TopicPartition, AtomicInteger> flowControl = new ConcurrentHashMap<>();
 
-    public KafkaController(KafkaConsumer<?, ?> kafkaConsumer, MessageStream messageStream, String topic) {
+    public KafkaController(Consumer<?, ?> kafkaConsumer, MessageStream messageStream, String topic) {
         this.kafkaConsumer = kafkaConsumer;
         this.messageStream = messageStream;
         messageStream.addTopic(topic);

--- a/connectors/kafka/src/main/java/forklift/controller/KafkaController.java
+++ b/connectors/kafka/src/main/java/forklift/controller/KafkaController.java
@@ -237,7 +237,7 @@ public class KafkaController {
     private class RebalanceListener implements ConsumerRebalanceListener {
         @Override
         public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
-            log.debug("controlLoop partitions revoked");
+            log.debug("controlLoop partitions revoked with generations {}", generations);
             try {
                 for (TopicPartition partition : partitions) {
                     generations.get(partition).unassign();
@@ -263,6 +263,8 @@ public class KafkaController {
                 final Generation generation = generations.computeIfAbsent(partition, ignored -> new Generation());
                 generation.assignNextGeneration();
             }
+
+            log.debug("controlLoop partitions assigned with generations {}", generations);
 
             acknowledgmentHandler.addPartitions(partitions);
             for (TopicPartition partition : partitions) {

--- a/connectors/kafka/src/main/java/forklift/message/Generation.java
+++ b/connectors/kafka/src/main/java/forklift/message/Generation.java
@@ -1,0 +1,26 @@
+package forklift.message;
+
+/** Represents the abstract time during which a record belonging to a dataset was acquired. */
+public class Generation {
+    /** Number of the currently assigned generation, or -1 if there is no currently assigned generation */
+    private volatile long generationNumber = -1;
+
+    /** Generation number stored while unassigned, removes the need for read locking */
+    private volatile long storedGenerationNumber  = -1;
+
+    public boolean assigned() { return generationNumber != -1; }
+    public long generationNumber() { return generationNumber; }
+
+    public synchronized void assignNextGeneration() {
+        this.storedGenerationNumber += 1;
+        this.generationNumber = storedGenerationNumber;
+    }
+
+    public synchronized void unassign() {
+        this.generationNumber = -1;
+    }
+
+    public boolean acceptsGeneration(final long otherGenerationNumber) {
+        return otherGenerationNumber != -1 && otherGenerationNumber == generationNumber;
+    }
+}

--- a/connectors/kafka/src/main/java/forklift/message/KafkaMessage.java
+++ b/connectors/kafka/src/main/java/forklift/message/KafkaMessage.java
@@ -12,10 +12,15 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 public class KafkaMessage extends ForkliftMessage {
     private final KafkaController controller;
     private final ConsumerRecord<?, ?> consumerRecord;
+    private final Generation latestGeneration;
+    private final long createdGenerationNumber;
 
-    public KafkaMessage(KafkaController controller, ConsumerRecord<?, ?> consumerRecord) {
+    public KafkaMessage(KafkaController controller, ConsumerRecord<?, ?> consumerRecord, Generation latestGeneration) {
         this.controller = controller;
         this.consumerRecord = consumerRecord;
+        this.latestGeneration = latestGeneration;
+        this.createdGenerationNumber = latestGeneration.generationNumber();
+
         createMessage();
     }
 
@@ -25,6 +30,8 @@ public class KafkaMessage extends ForkliftMessage {
 
     @Override
     public boolean acknowledge() throws ConnectorException {
+        if (!latestGeneration.acceptsGeneration(createdGenerationNumber)) { return false; }
+
         try {
             return controller.acknowledge(consumerRecord);
         } catch (InterruptedException e) {

--- a/connectors/kafka/src/main/java/forklift/message/KafkaMessage.java
+++ b/connectors/kafka/src/main/java/forklift/message/KafkaMessage.java
@@ -12,14 +12,12 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 public class KafkaMessage extends ForkliftMessage {
     private final KafkaController controller;
     private final ConsumerRecord<?, ?> consumerRecord;
-    private final Generation latestGeneration;
-    private final long createdGenerationNumber;
+    private final long generationNumber;
 
-    public KafkaMessage(KafkaController controller, ConsumerRecord<?, ?> consumerRecord, Generation latestGeneration) {
+    public KafkaMessage(KafkaController controller, ConsumerRecord<?, ?> consumerRecord, long generationNumber) {
         this.controller = controller;
         this.consumerRecord = consumerRecord;
-        this.latestGeneration = latestGeneration;
-        this.createdGenerationNumber = latestGeneration.generationNumber();
+        this.generationNumber = generationNumber;
 
         createMessage();
     }
@@ -30,10 +28,8 @@ public class KafkaMessage extends ForkliftMessage {
 
     @Override
     public boolean acknowledge() throws ConnectorException {
-        if (!latestGeneration.acceptsGeneration(createdGenerationNumber)) { return false; }
-
         try {
-            return controller.acknowledge(consumerRecord);
+            return controller.acknowledge(consumerRecord, generationNumber);
         } catch (InterruptedException e) {
             throw new ConnectorException("Error acknowledging message");
         }

--- a/connectors/kafka/src/main/java/forklift/message/KafkaMessage.java
+++ b/connectors/kafka/src/main/java/forklift/message/KafkaMessage.java
@@ -8,8 +8,12 @@ import forklift.producers.KafkaForkliftProducer;
 
 import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class KafkaMessage extends ForkliftMessage {
+    private static final Logger log = LoggerFactory.getLogger(KafkaMessage.class);
+
     private final KafkaController controller;
     private final ConsumerRecord<?, ?> consumerRecord;
     private final long generationNumber;
@@ -29,7 +33,10 @@ public class KafkaMessage extends ForkliftMessage {
     @Override
     public boolean acknowledge() throws ConnectorException {
         try {
-            return controller.acknowledge(consumerRecord, generationNumber);
+            final boolean acknowledged = controller.acknowledge(consumerRecord, generationNumber);
+            log.debug("Acknoledgment for topic: {} partition: {} offset: {} generation: {} successful: {}",
+                      consumerRecord.topic(), consumerRecord.partition(), consumerRecord.offset(), generationNumber, acknowledged);
+            return acknowledged;
         } catch (InterruptedException e) {
             throw new ConnectorException("Error acknowledging message");
         }

--- a/connectors/kafka/src/test/java/forklift/controller/GenerationTests.java
+++ b/connectors/kafka/src/test/java/forklift/controller/GenerationTests.java
@@ -1,0 +1,43 @@
+package forklift.controller;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class GenerationTests {
+    @Test
+    public void acceptsCurrentGeneration() {
+        final Generation generation = new Generation();
+        generation.assignNextGeneration();
+
+        final long currentGeneration = generation.generationNumber();
+        Assert.assertTrue(generation.acceptsGeneration(currentGeneration));
+    }
+
+    @Test
+    public void rejectsUnassignedGeneration() {
+        final Generation generation = new Generation();
+        generation.assignNextGeneration();
+        generation.unassign();
+
+        final long currentGeneration = generation.generationNumber();
+        Assert.assertFalse(generation.acceptsGeneration(currentGeneration));
+
+        // check that the number taken from the unassigned generation is still rejected later
+        generation.assignNextGeneration();
+        generation.unassign();
+
+        Assert.assertFalse(generation.acceptsGeneration(currentGeneration));
+    }
+
+    @Test
+    public void rejectsOldGeneration() {
+        final Generation generation = new Generation();
+        generation.assignNextGeneration();
+
+        final long currentGeneration = generation.generationNumber();
+        generation.unassign();
+        generation.assignNextGeneration();
+
+        Assert.assertFalse(generation.acceptsGeneration(currentGeneration));
+    }
+}

--- a/connectors/kafka/src/test/java/forklift/controller/KafkaControllerRebalanceTests.java
+++ b/connectors/kafka/src/test/java/forklift/controller/KafkaControllerRebalanceTests.java
@@ -1,0 +1,175 @@
+package forklift.controller;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import forklift.Forklift;
+import forklift.connectors.ForkliftConnectorI;
+import forklift.consumer.Consumer;
+import forklift.consumer.ConsumerThread;
+import forklift.consumer.KafkaTopicConsumer;
+import forklift.decorators.Message;
+import forklift.decorators.MultiThreaded;
+import forklift.decorators.OnMessage;
+import forklift.message.MessageStream;
+import forklift.schemas.UserRegistered;
+import forklift.source.decorators.Topic;
+import forklift.util.ConsumerRecordCreator;
+import forklift.util.TestConsumer;
+
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.inject.Inject;
+
+public class KafkaControllerRebalanceTests {
+    private static final String TOPIC = "user.controller.test";
+    private AtomicBoolean donePolling;
+    private TestConsumer<String, GenericRecord> kafkaConsumer;
+    private MessageStream messageStream;
+    private KafkaController controller;
+
+    private Consumer consumer;
+    private ConsumerThread consumerThread;
+    private KafkaTopicConsumer forkliftConsumer;
+    private ForkliftConnectorI mockConnector;
+    private Forklift forklift;
+
+    @Before
+    public void setup() throws Exception {
+        donePolling = new AtomicBoolean(false);
+        kafkaConsumer = new TestConsumer<>(2, 2);
+        messageStream = new MessageStream();
+        controller = spy(new KafkaController(kafkaConsumer, messageStream, TOPIC));
+
+        forkliftConsumer = new KafkaTopicConsumer(TOPIC, controller);
+        mockConnector = mock(ForkliftConnectorI.class);
+        when(mockConnector.getConsumerForSource(any())).thenReturn(forkliftConsumer);
+
+        forklift = new Forklift();
+        forklift.setConnector(mockConnector);
+
+        consumer = new Consumer(LoggingConsumer.class, forklift);
+        consumer.setOutOfMessages(consumer -> {
+            synchronized (donePolling) {
+                donePolling.set(true);
+                donePolling.notifyAll();
+            }
+        });
+        consumerThread = new ConsumerThread(consumer);
+    }
+
+    private void waitForIt() {
+        while (!donePolling.get()) {
+            synchronized (donePolling) {
+                try {
+                    donePolling.wait();
+                } catch (InterruptedException e) {}
+            }
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testRecordsAfterRebalance() throws Exception {
+        final TopicPartition partition = new TopicPartition(TOPIC, 0);
+        final LinkedHashMap<String, GenericRecord> records = new LinkedHashMap<String, GenericRecord>() {{
+            put("Bobby", new GenericData.Record(UserRegistered.getClassSchema()) {{
+                put("firstName", "Bobby");
+                put("lastName", "Foo");
+                put("email", "bfoo@yahoo.com");
+            }});
+            put("Billy", new GenericData.Record(UserRegistered.getClassSchema()) {{
+                put("firstName", "Billy");
+                put("lastName", "Joseph");
+                put("email", "bjoseph@aol.com");
+            }});
+            put("Dude", new GenericData.Record(UserRegistered.getClassSchema()) {{
+                put("firstName", "Dude");
+                put("lastName", "Duderson");
+                put("email", "dduderson@gmail.com");
+            }});
+            put("Bobby2", new GenericData.Record(UserRegistered.getClassSchema()) {{
+                put("firstName", "Bobby2");
+                put("lastName", "Foo");
+                put("email", "bfoo@yahoo.com");
+            }});
+            put("Billy2", new GenericData.Record(UserRegistered.getClassSchema()) {{
+                put("firstName", "Billy2");
+                put("lastName", "Joseph");
+                put("email", "bjoseph@aol.com");
+            }});
+            put("Dude2", new GenericData.Record(UserRegistered.getClassSchema()) {{
+                put("firstName", "Dude2");
+                put("lastName", "Duderson");
+                put("email", "dduderson@gmail.com");
+            }});
+        }};
+        final List<ConsumerRecord<String, GenericRecord>> recordList = ConsumerRecordCreator.from(partition, records);
+        final List<TopicPartition> partitions = Arrays.asList(partition);
+
+        kafkaConsumer.setPartitionsForTopic(TOPIC, new HashSet<>(partitions));
+        kafkaConsumer.setPartitionRecords(partition, recordList);
+
+        kafkaConsumer.queueRebalance(partitions);
+        kafkaConsumer.queueRebalance(partitions);
+        kafkaConsumer.queueRebalance(partitions);
+        kafkaConsumer.runOnceBeforePoll(() -> {});
+        kafkaConsumer.queueRebalance(partitions);
+        kafkaConsumer.queueRebalance(partitions);
+
+        controller.start();
+        consumerThread.start();
+
+        waitForIt();
+
+        consumerThread.shutdown();
+        controller.stop(10, TimeUnit.MILLISECONDS);
+
+        final ArgumentCaptor<ConsumerRecord<?, ?>> captor = ArgumentCaptor.forClass((Class) ConsumerRecord.class);
+        verify(controller, atLeast(0)).acknowledge(captor.capture());
+
+        final List<ConsumerRecord<?, ?>> ackedRecords = captor.getAllValues();
+        Assert.assertEquals(recordList.size(), ackedRecords.size());
+        Assert.assertEquals(recordList, ackedRecords);
+    }
+
+    @Topic("ignored")
+    @MultiThreaded(1)
+    public static class LoggingConsumer {
+        private String message;
+
+        @Inject
+        public LoggingConsumer(@Message String message) {
+            this.message = message;
+        }
+
+        @OnMessage
+        public void onMessage() {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {}
+
+            System.out.println("Processed message: " + message);
+        }
+    }
+}

--- a/connectors/kafka/src/test/java/forklift/controller/KafkaControllerRebalanceTests.java
+++ b/connectors/kafka/src/test/java/forklift/controller/KafkaControllerRebalanceTests.java
@@ -9,12 +9,14 @@ import static org.mockito.Mockito.when;
 
 import forklift.Forklift;
 import forklift.connectors.ForkliftConnectorI;
+import forklift.connectors.ForkliftMessage;
 import forklift.consumer.Consumer;
 import forklift.consumer.ConsumerThread;
 import forklift.consumer.KafkaTopicConsumer;
 import forklift.decorators.Message;
 import forklift.decorators.MultiThreaded;
 import forklift.decorators.OnMessage;
+import forklift.message.KafkaMessage;
 import forklift.message.MessageStream;
 import forklift.schemas.UserRegistered;
 import forklift.source.decorators.Topic;
@@ -31,6 +33,7 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -43,6 +46,8 @@ import javax.inject.Inject;
 
 public class KafkaControllerRebalanceTests {
     private static final String TOPIC = "user.controller.test";
+    private static List<ConsumerRecord<?, ?>> processedRecords;
+
     private AtomicBoolean donePolling;
     private TestConsumer<String, GenericRecord> kafkaConsumer;
     private MessageStream messageStream;
@@ -57,6 +62,8 @@ public class KafkaControllerRebalanceTests {
     @Before
     public void setup() throws Exception {
         donePolling = new AtomicBoolean(false);
+        processedRecords = new ArrayList<>();
+
         kafkaConsumer = new TestConsumer<>(2, 2);
         messageStream = new MessageStream();
         controller = spy(new KafkaController(kafkaConsumer, messageStream, TOPIC));
@@ -145,21 +152,18 @@ public class KafkaControllerRebalanceTests {
         consumerThread.shutdown();
         controller.stop(10, TimeUnit.MILLISECONDS);
 
-        final ArgumentCaptor<ConsumerRecord<?, ?>> captor = ArgumentCaptor.forClass((Class) ConsumerRecord.class);
-        verify(controller, atLeast(0)).acknowledge(captor.capture());
-
-        final List<ConsumerRecord<?, ?>> ackedRecords = captor.getAllValues();
-        Assert.assertEquals(recordList.size(), ackedRecords.size());
-        Assert.assertEquals(recordList, ackedRecords);
+        // since the consumer has one thread, the messages should be processed in order
+        Assert.assertEquals(recordList.size(), processedRecords.size());
+        Assert.assertEquals(recordList, processedRecords);
     }
 
     @Topic("ignored")
     @MultiThreaded(1)
     public static class LoggingConsumer {
-        private String message;
+        private ForkliftMessage message;
 
         @Inject
-        public LoggingConsumer(@Message String message) {
+        public LoggingConsumer(@Message ForkliftMessage message) {
             this.message = message;
         }
 
@@ -169,7 +173,9 @@ public class KafkaControllerRebalanceTests {
                 Thread.sleep(100);
             } catch (InterruptedException e) {}
 
-            System.out.println("Processed message: " + message);
+            System.out.println("Processed message: " + message.getMsg());
+
+            processedRecords.add(((KafkaMessage) message).getConsumerRecord());
         }
     }
 }

--- a/connectors/kafka/src/test/java/forklift/message/KafkaMessageTests.java
+++ b/connectors/kafka/src/test/java/forklift/message/KafkaMessageTests.java
@@ -3,9 +3,13 @@ package forklift.message;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
 import forklift.connectors.ConnectorException;
 import forklift.controller.KafkaController;
+
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.Before;
 import org.junit.Test;
@@ -15,27 +19,58 @@ public class KafkaMessageTests {
     private KafkaController controller;
     private KafkaMessage message;
     private ConsumerRecord record;
+    private Generation generation;
 
     @Before
     public void setup() {
         controller = mock(KafkaController.class);
         record = new ConsumerRecord("testTopic", 0, 1L, "key", "value");
-        message = new KafkaMessage(controller, record);
+        generation = new Generation();
+        generation.assignNextGeneration();
+
+        message = new KafkaMessage(controller, record, generation);
     }
 
     @Test
     public void acknowledgeFalseTest() throws ConnectorException, InterruptedException {
-
         when(controller.acknowledge(record)).thenReturn(false);
-        boolean acknowledged = message.acknowledge();
-        assertFalse(acknowledged);
 
+        boolean acknowledged = message.acknowledge();
+
+        assertFalse(acknowledged);
+        verify(controller).acknowledge(record);
     }
 
     @Test
     public void acknowledgeCallsControllerSuccess() throws ConnectorException, InterruptedException {
         when(controller.acknowledge(record)).thenReturn(true);
+
         boolean acknowledged = message.acknowledge();
+
         assertTrue(acknowledged);
+        verify(controller).acknowledge(record);
+    }
+
+    @Test
+    public void acknowledgeFailsWithUnassignedGeneration() throws ConnectorException, InterruptedException {
+        generation.unassign();
+        when(controller.acknowledge(record)).thenReturn(true);
+
+        boolean acknowledged = message.acknowledge();
+
+        assertFalse(acknowledged);
+        verify(controller, never()).acknowledge(record);
+    }
+
+    @Test
+    public void acknowledgeFailsWithOldGeneration() throws ConnectorException, InterruptedException {
+        generation.unassign();
+        generation.assignNextGeneration();
+        when(controller.acknowledge(record)).thenReturn(true);
+
+        boolean acknowledged = message.acknowledge();
+
+        assertFalse(acknowledged);
+        verify(controller, never()).acknowledge(record);
     }
 }

--- a/connectors/kafka/src/test/java/forklift/util/ConsumerRecordCreator.java
+++ b/connectors/kafka/src/test/java/forklift/util/ConsumerRecordCreator.java
@@ -1,0 +1,22 @@
+package forklift.util;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ConsumerRecordCreator {
+    public static <K, V> List<ConsumerRecord<K, V>> from(TopicPartition partition, LinkedHashMap<K, V> values) {
+        final List<ConsumerRecord<K, V>> result = new ArrayList<>();
+
+        int offset = 0;
+        for (Map.Entry<K, V> entry : values.entrySet()) {
+            result.add(new ConsumerRecord<K, V>(partition.topic(), partition.partition(), offset, entry.getKey(), entry.getValue()));
+            offset++;
+        }
+        return result;
+    }
+}

--- a/connectors/kafka/src/test/java/forklift/util/TestConsumer.java
+++ b/connectors/kafka/src/test/java/forklift/util/TestConsumer.java
@@ -1,0 +1,272 @@
+package forklift.util;
+
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
+import org.apache.kafka.clients.consumer.OffsetCommitCallback;
+import org.apache.kafka.clients.consumer.internals.NoOpConsumerRebalanceListener;
+
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import java.util.stream.Collectors;
+
+/**
+ A minimal implementation of the {@link Consumer} interface designed to simulate consuming records during a rebalance.
+ */
+public final class TestConsumer<K, V> implements Consumer<K, V> {
+    private final long maxPollRecords;
+    private final long maxPollRecordsPerPartition;
+    private Map<String, Set<TopicPartition>> partitionsForTopic = new HashMap<>();
+    private Map<TopicPartition, List<ConsumerRecord<K, V>>> recordsForPartition = new HashMap<>();
+    private Queue<Runnable> beforePollActions = new LinkedBlockingQueue<>();
+
+    private Set<String> subscription= new HashSet<>();
+    private Set<TopicPartition> assignment = new HashSet<>();
+    private Set<TopicPartition> pausedPartitions = new HashSet<>();
+    private ConsumerRebalanceListener listener;
+
+    private Map<TopicPartition, Long> fetchPositions = new HashMap<>();
+    private Map<TopicPartition, Long> commitPositions = new HashMap<>();
+
+
+    public TestConsumer(long maxPollRecords, long maxPollRecordsPerPartition) {
+        this.maxPollRecords = maxPollRecords;
+        this.maxPollRecordsPerPartition = maxPollRecordsPerPartition;
+    }
+
+    /*
+       -----
+       Subscription and assignment methods
+       -----
+    */
+    @Override public void assign(Collection<TopicPartition> assignment) {
+        this.assignment = new HashSet<>(assignment);
+    }
+    @Override public Set<TopicPartition> assignment() { return assignment; }
+
+    @Override public void subscribe(Collection<String> topics) {
+        subscribe(topics, null);
+    }
+    @Override public void subscribe(java.util.regex.Pattern pattern, ConsumerRebalanceListener listener) {
+        final Collection<String> matchingTopics = partitionsForTopic.keySet().stream()
+            .filter(topic -> pattern.matcher(topic).matches())
+            .collect(Collectors.toList());
+
+        subscribe(matchingTopics, listener);
+    }
+    @Override public void subscribe(Collection<String> topics, ConsumerRebalanceListener listener) {
+        this.listener = listener;
+        this.subscription = new HashSet<>(topics);
+
+        if (this.listener == null) { this.listener = new NoOpConsumerRebalanceListener(); }
+
+        assignment.clear();
+        topics.forEach(this::assignPartitionsForTopic);
+        this.listener.onPartitionsAssigned(assignment);
+    }
+    private void assignPartitionsForTopic(String topic) {
+        final Set<TopicPartition> assignedPartitions = partitionsForTopic.getOrDefault(topic, Collections.emptySet());
+
+        assignment.addAll(assignedPartitions);
+    }
+    @Override public void unsubscribe() {
+        assignment.clear();
+        subscription.clear();
+    }
+    @Override public Set<String> subscription() { return subscription; }
+
+    /*
+      -----
+      Pause and Resume functionality
+      -----
+    */
+    @Override public void pause(Collection<TopicPartition> partitions) {
+        pausedPartitions.addAll(partitions);
+    }
+    @Override public void resume(Collection<TopicPartition> partitions) {
+        pausedPartitions.removeAll(partitions);
+    }
+    @Override public Set<TopicPartition> paused() { return pausedPartitions; }
+
+    /*
+      -----
+      Position managament functionality
+      -----
+    */
+    @Override public void seek(TopicPartition partition, long offset) {
+        fetchPositions.put(partition, offset);
+    }
+    @Override public void seekToBeginning(Collection<TopicPartition> partitions) {
+        partitions.forEach(partition -> seek(partition, 0));
+    }
+    @Override public void seekToEnd(Collection<TopicPartition> partitions) {
+        partitions.forEach(partition -> {
+            final long endOffset = recordsForPartition.get(partition).size();
+            seek(partition, endOffset);
+        });
+    }
+    @Override public Map<TopicPartition, Long> beginningOffsets(Collection<TopicPartition> partitions) {
+        return partitions.stream()
+            .collect(Collectors.toMap(Function.identity(), partition -> 0L));
+    }
+    @Override public Map<TopicPartition, Long> endOffsets(Collection<TopicPartition> partitions) {
+        return partitions.stream()
+            .collect(Collectors.toMap(Function.identity(), partition -> Long.valueOf(recordsForPartition.get(partition).size())));
+    }
+    @Override public Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(Map<TopicPartition, Long> timestampsToSearch) {
+        return timestampsToSearch.entrySet().stream()
+            .collect(Collectors.toMap(Map.Entry::getKey, entry -> new OffsetAndTimestamp(0L, entry.getValue())));
+    }
+
+    @Override public long position(TopicPartition partition) {
+        return fetchPositions.getOrDefault(partition, 0L);
+    }
+
+    /*
+      -----
+      Commit functionality
+      -----
+    */
+    @Override public void commitSync() { commitAsync(); }
+    @Override public void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets) { commitAsync(offsets, null); }
+    @Override public void commitAsync() { commitAsync(fetchPositionsAndMetadata(), null); }
+    @Override public void commitAsync(OffsetCommitCallback callback) { commitAsync(fetchPositionsAndMetadata(), callback); }
+    @Override public void commitAsync(Map<TopicPartition, OffsetAndMetadata> offsets, OffsetCommitCallback callback) {
+        offsets.entrySet().forEach(entry -> {
+            final long offset = entry.getValue().offset();
+
+            commitPositions.put(entry.getKey(), offset);
+        });
+    }
+
+    @Override public OffsetAndMetadata committed(TopicPartition partition) {
+        return new OffsetAndMetadata(commitPositions.get(partition));
+    }
+
+    private Map<TopicPartition, OffsetAndMetadata> fetchPositionsAndMetadata() {
+        return fetchPositions.entrySet().stream()
+            .collect(Collectors.toMap(Map.Entry::getKey, entry -> new OffsetAndMetadata(entry.getValue())));
+    }
+
+    /*
+      -----
+      Miscellaneous functionality
+      -----
+    */
+    @Override public void close() {}
+    @Override public void close(long timeout, java.util.concurrent.TimeUnit unit) {}
+    @Override public void wakeup() {}
+    @Override public Map<MetricName, ? extends Metric> metrics() { return Collections.emptyMap(); }
+    @Override public List<PartitionInfo> partitionsFor(String topic) {
+        return listTopics().get(topic);
+    }
+    @Override public Map<String, List<PartitionInfo>> listTopics() {
+        return partitionsForTopic.entrySet().stream()
+            .collect(Collectors.toMap(Map.Entry::getKey, entry -> {
+                 return entry.getValue().stream()
+                     .map(TestConsumer::toDefaultPartitionInfo)
+                     .collect(Collectors.toList());
+             }));
+    }
+
+    private static PartitionInfo toDefaultPartitionInfo(TopicPartition partition) {
+        return new PartitionInfo(
+            partition.topic(),
+            partition.partition(),
+            Node.noNode(),
+            new Node[0],
+            new Node[0]);
+    }
+
+    /*
+      ----
+      Poll functionality
+      ----
+    */
+    public ConsumerRecords<K, V> poll(long timeout) {
+        final Runnable action = beforePollActions.poll();
+        if (action != null) { action.run(); }
+
+        if (timeout == 0) { return new ConsumerRecords<>(Collections.emptyMap()); }
+
+        final AtomicLong remainingRecordsInBatch = new AtomicLong(maxPollRecords);
+        final Map<TopicPartition, List<ConsumerRecord<K, V>>> recordMap = assignment.stream()
+            .flatMap(partition -> {
+                    if (pausedPartitions.contains(partition)) { return Stream.empty(); }
+                    if (remainingRecordsInBatch.get() <= 0) { return Stream.empty(); }
+
+                    final List<ConsumerRecord<K, V>> partitionRecords = recordsForPartition.get(partition);
+                    final long fetchPosition = fetchPositions.computeIfAbsent(partition, part -> commitPositions.getOrDefault(part, 0L));
+                    final long remainingRecordsInPartition = partitionRecords.size() - fetchPosition;
+                    final long numFetchedRecords = Math.min(remainingRecordsInPartition, remainingRecordsInBatch.get());
+
+                    final List<ConsumerRecord<K, V>> fetchedRecords = partitionRecords.subList((int) fetchPosition, (int) (fetchPosition + numFetchedRecords));
+
+                    fetchPositions.put(partition, fetchPosition + numFetchedRecords);
+                    remainingRecordsInBatch.addAndGet(-numFetchedRecords);
+
+                    return Stream.of(new AbstractMap.SimpleEntry<TopicPartition, List<ConsumerRecord<K, V>>>(partition, fetchedRecords));
+                })
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        return new ConsumerRecords<K, V>(recordMap);
+    }
+
+    /*
+      -----
+      Mock control methods
+      -----
+    */
+    public void setPartitionsForTopic(String topic, Set<TopicPartition> partitions) {
+        partitionsForTopic.put(topic, partitions);
+    }
+
+    public void setPartitionRecords(TopicPartition partition, List<ConsumerRecord<K, V>> records) {
+        recordsForPartition.put(partition, records);
+    }
+
+    /*
+      -----
+      Consumer intraction functionality
+      -----
+    */
+
+    public void runOnceBeforePoll(Runnable action) {
+        beforePollActions.add(action);
+    }
+
+    /* Perform a rebalance for the given partitions before fetching records in the next poll */
+    public void queueRebalance(Collection<TopicPartition> partitions) {
+        runOnceBeforePoll(() -> performRebalance(partitions));
+    }
+
+    private void performRebalance(Collection<TopicPartition> partitions) {
+        listener.onPartitionsRevoked(partitions);
+
+        partitions.forEach(partition -> {
+            fetchPositions.remove(partition);
+        });
+        resume(partitions);
+
+        listener.onPartitionsAssigned(partitions);
+    }
+}

--- a/connectors/kafka/src/test/java/forklift/util/TestConsumer.java
+++ b/connectors/kafka/src/test/java/forklift/util/TestConsumer.java
@@ -212,13 +212,14 @@ public final class TestConsumer<K, V> implements Consumer<K, V> {
         final Map<TopicPartition, List<ConsumerRecord<K, V>>> recordMap = assignment.stream()
             .flatMap(partition -> {
                     if (pausedPartitions.contains(partition)) { return Stream.empty(); }
-                    if (remainingRecordsInBatch.get() <= 0) { return Stream.empty(); }
 
                     final List<ConsumerRecord<K, V>> partitionRecords = recordsForPartition.get(partition);
                     final long fetchPosition = fetchPositions.computeIfAbsent(partition, part -> commitPositions.getOrDefault(part, 0L));
+
                     final long remainingRecordsInPartition = partitionRecords.size() - fetchPosition;
                     final long numFetchedRecords = Math.min(remainingRecordsInPartition, remainingRecordsInBatch.get());
 
+                    if (numFetchedRecords == 0) { return Stream.empty(); }
                     final List<ConsumerRecord<K, V>> fetchedRecords = partitionRecords.subList((int) fetchPosition, (int) (fetchPosition + numFetchedRecords));
 
                     fetchPositions.put(partition, fetchPosition + numFetchedRecords);

--- a/core/src/main/java/forklift/concurrent/BlockingRejectedExecutionHandler.java
+++ b/core/src/main/java/forklift/concurrent/BlockingRejectedExecutionHandler.java
@@ -1,0 +1,20 @@
+package forklift.concurrent;
+
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.RejectedExecutionHandler;
+
+/**
+ * A rejected execution handler for a {@link ThreadPoolExecutor} that handles rejected
+ * tasks from a running thread pool by blocking.
+ */
+public class BlockingRejectedExecutionHandler implements RejectedExecutionHandler {
+    @Override
+    public void rejectedExecution(Runnable runnable, ThreadPoolExecutor executor) {
+        while (!executor.isShutdown()) {
+            try {
+                executor.getQueue().put(runnable);
+                return;
+            } catch (InterruptedException ignored) {}
+        }
+    }
+}

--- a/core/src/main/java/forklift/concurrent/BlockingRejectedExecutionHandler.java
+++ b/core/src/main/java/forklift/concurrent/BlockingRejectedExecutionHandler.java
@@ -8,13 +8,20 @@ import java.util.concurrent.RejectedExecutionHandler;
  * tasks from a running thread pool by blocking.
  */
 public class BlockingRejectedExecutionHandler implements RejectedExecutionHandler {
+    private static final Runnable NO_OP = () -> {};
+
     @Override
     public void rejectedExecution(Runnable runnable, ThreadPoolExecutor executor) {
-        while (!executor.isShutdown()) {
-            try {
-                executor.getQueue().put(runnable);
-                return;
-            } catch (InterruptedException ignored) {}
-        }
+        if (executor.isShutdown()) { return; }
+
+        try {
+            // wait for space in the queue
+            executor.getQueue().put(NO_OP);
+            executor.remove(NO_OP);
+
+            if (!executor.isShutdown()) {
+                executor.execute(runnable);
+            }
+        } catch (InterruptedException ignored) {}
     }
 }

--- a/core/src/main/java/forklift/consumer/Consumer.java
+++ b/core/src/main/java/forklift/consumer/Consumer.java
@@ -343,8 +343,9 @@ public class Consumer {
             // Shutdown the pool, but let actively executing work finish.
             if (threadPool != null) {
                 log.info("Shutting down thread pool - active {}", threadPool.getActiveCount());
-                blockQueue.clear();
                 threadPool.shutdown();
+                blockQueue.clear();
+
                 threadPool.awaitTermination(10, TimeUnit.SECONDS);
             }
         } catch (ConnectorException e) {

--- a/core/src/test/java/forklift/concurrent/BlockingRejectedExecutionHandlerTests.java
+++ b/core/src/test/java/forklift/concurrent/BlockingRejectedExecutionHandlerTests.java
@@ -1,0 +1,101 @@
+package forklift.concurrent;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.times;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class BlockingRejectedExecutionHandlerTests {
+    private ThreadPoolExecutor pool;
+    private BlockingQueue<Runnable> queue;
+    private RejectedExecutionHandler handler;
+
+    @Before
+    public void setup() {
+        this.queue = new ArrayBlockingQueue<>(1);
+        this.pool = new ThreadPoolExecutor(1, 1, 10, TimeUnit.MILLISECONDS, this.queue);
+        this.handler = Mockito.spy(new BlockingRejectedExecutionHandler());
+        this.pool.setRejectedExecutionHandler(handler);
+    }
+
+    @After
+    public void shutdown() throws Exception {
+        pool.shutdownNow();
+        pool.awaitTermination(100, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    public void testRejectedExecutionTriggered() {
+        final AtomicBoolean blockCondition = new AtomicBoolean(false);
+        final AtomicBoolean finishCondition = new AtomicBoolean(false);
+
+        // fill up the queue and executing threads - nothing should be rejected yet
+        startBlockedTask(blockCondition, pool);
+        startBlockedTask(blockCondition, pool);
+        Mockito.verify(handler, times(0)).rejectedExecution(any(), any());
+
+        doAsync(() -> {
+            pool.execute(() -> {
+                synchronized (finishCondition) {
+                    finishCondition.set(true);
+                    finishCondition.notifyAll();
+                }
+            });
+        });
+
+        // make sure that the third task on the pool doesn't get executed yet, but the rejected execution handler has started
+        synchronized (finishCondition) {
+            try {
+                finishCondition.wait(100);
+            } catch (InterruptedException ignored) {}
+        }
+        Assert.assertFalse(finishCondition.get());
+        Mockito.verify(handler, times(1)).rejectedExecution(any(), any());
+
+        // unblock the queued threads
+        synchronized (blockCondition) {
+            blockCondition.set(true);
+            blockCondition.notifyAll();
+        }
+
+        // check that the queued task eventually gets ran
+        synchronized (finishCondition) {
+            try {
+                finishCondition.wait(100);
+            } catch (InterruptedException ignored) {}
+        }
+        Assert.assertTrue(finishCondition.get());
+        Mockito.verify(handler, times(1)).rejectedExecution(any(), any());
+    }
+
+    private void startBlockedTask(AtomicBoolean condition, ExecutorService executor) {
+        executor.submit(() -> {
+            while (!condition.get()) {
+                synchronized (condition) {
+                    try {
+                        condition.wait();
+                    } catch (InterruptedException ignored) {}
+                }
+            }
+        });
+    }
+
+    private void doAsync(Runnable action) {
+        final ExecutorService service =  Executors.newSingleThreadExecutor();
+        service.execute(action);
+        service.shutdown();
+    }
+}


### PR DESCRIPTION
### Summary
- Handle rejected executions by blocking to enqueue the rejected message.
- Invalidate records based on a new feature - generation number
- Shutdown consumers faster by emptying the work queue first
- Add test case for duplicate processing records

### Overview
We are seeing two different kinds of undesired processing: missed messages, and duplicate messages. Below I describe my current reasoning for what is causing these issues and how it can be fixed.

### Missed Messages
The missed messages seem to be caused by out-of-order processing created by the `CallerRunsPolicy` used for handling messages that can't be queued on the `Consumer` side, combined with a large consumer queue that can't be fully processed in a normal shutdown sequence.

My solution for this is to have rejected executions wait to be queued on the consumer's thread. (An alternative policy would be to have the caller process a message at the head of the work queue, but I prefer to keep the processing in the consumer's thread pool.)

### Duplicate Messages
The duplicate messages are most likely caused by incorrect behavior around rebalancing, where stale messages are kept after a rebalance. (This has been validated by the new test case.)

There are two general approaches here:
- Only let valid records exit `MessageStream` (requiring truly ordered consumption on a partition) and removing cached records as soon as partitions are revoked.
- Filter out invalid messages when the consumer first processes them, having some way of indicating the oldness of a message

Although the first option is probably better practice, the second option is quicker to write and lets us avoid risky architectural changes.

#### Solution
This PR introduces a "generation" managed by `KafkaController` for each topic-partition, and updated as partitions are assigned and revoked. When a message is created, this generation number is captured, and if it doesn't match the latest generation number for the message's partition that message is skipped by `KafkaMessage#acknowledge`.

---

Please Review: @AFrieze @dcshock @seanmrogers 