### PR TITLE
Allow Adding Additional Parameters for Kafka Clients

### DIFF
--- a/connectors/kafka/src/main/java/forklift/connectors/KafkaConnector.java
+++ b/connectors/kafka/src/main/java/forklift/connectors/KafkaConnector.java
@@ -112,7 +112,7 @@ public class KafkaConnector implements ForkliftConnectorI {
         //We do nothing here.  Consumer and producer are created when needed
     }
 
-    private KafkaProducer createKafkaProducer() {
+    Properties getProducerProperties() {
         Properties producerProperties = new Properties();
         producerProperties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaHosts);
         producerProperties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
@@ -125,10 +125,14 @@ public class KafkaConnector implements ForkliftConnectorI {
             producerProperties.putAll(addedProducerProperties);
         }
 
-        return new KafkaProducer(producerProperties);
+        return producerProperties;
     }
 
-    private KafkaController createController(String topicName) {
+    private KafkaProducer createKafkaProducer() {
+        return new KafkaProducer(getProducerProperties());
+    }
+
+    Properties getConsumerProperties() {
         Properties props = new Properties();
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaHosts);
         props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
@@ -144,7 +148,11 @@ public class KafkaConnector implements ForkliftConnectorI {
             props.putAll(addedConsumerProperties);
         }
 
-        final KafkaConsumer<?, ?> kafkaConsumer = new KafkaConsumer(props);
+        return props;
+    }
+
+    private KafkaController createController(String topicName) {
+        final KafkaConsumer<?, ?> kafkaConsumer = new KafkaConsumer(getConsumerProperties());
         return new KafkaController(kafkaConsumer, new MessageStream(), topicName);
     }
 

--- a/connectors/kafka/src/test/java/forklift/connectors/KafkaConnectorTests.java
+++ b/connectors/kafka/src/test/java/forklift/connectors/KafkaConnectorTests.java
@@ -1,0 +1,44 @@
+package forklift.connectors;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Properties;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class KafkaConnectorTests {
+    private final KafkaConnector connector;
+
+    public KafkaConnectorTests() {
+        this.connector = new KafkaConnector("fake", "fake", "foo");
+    }
+
+    @Test
+    public void testConsumerPropertiesOverride() {
+        final Map<Object, Object> addedProperties = new HashMap<>();
+        addedProperties.put("foo", "bar");
+        addedProperties.put(ConsumerConfig.GROUP_ID_CONFIG, "override");
+
+        connector.setAddedConsumerProperties(addedProperties);
+
+        final Properties props = connector.getConsumerProperties();
+        Assert.assertEquals("bar", props.get("foo"));
+        Assert.assertEquals("override", props.get(ConsumerConfig.GROUP_ID_CONFIG));
+    }
+
+    @Test
+    public void testProducerPropertiesOverride() {
+        final Map<Object, Object> addedProperties = new HashMap<>();
+        addedProperties.put("foo", "bar");
+        addedProperties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "override");
+
+        connector.setAddedProducerProperties(addedProperties);
+
+        final Properties props = connector.getProducerProperties();
+        Assert.assertEquals("bar", props.get("foo"));
+        Assert.assertEquals("override", props.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG));
+    }
+}


### PR DESCRIPTION
#### Changes:

- Add two public methods `setAddedConsumerProperties` and `setAddedProducerProperties` to allow users of `KafkaConnector` to add (and potentially override) the properties of kafka clients.

This change is pretty straight-forward, and should help handle concerns that crosscut `KafkaConnector` (e.g. security).

----

Please Review: @AFrieze @seanmrogers 