### PR TITLE
Modify consumer method annotations to be detected on superclasses

### DIFF
--- a/core/src/main/java/forklift/consumer/ConsumerAnnotationDetector.java
+++ b/core/src/main/java/forklift/consumer/ConsumerAnnotationDetector.java
@@ -1,0 +1,151 @@
+package forklift.consumer;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import forklift.decorators.Config;
+import forklift.decorators.On;
+import forklift.decorators.OnMessage;
+import forklift.decorators.OnValidate;
+import forklift.decorators.Ons;
+import forklift.decorators.Order;
+import forklift.decorators.Response;
+
+public class ConsumerAnnotationDetector {
+    private final Map<Class, Map<Class<?>, List<Field>>> injectFields;
+    private final Class<?> msgHandler;
+    private final List<Method> onMessage;
+    private final List<Method> onValidate;
+    private final List<Method> onResponse;
+    private final Map<String, List<MessageRunnable>> orderQueue;
+    private final Map<ProcessStep, List<Method>> onProcessStep;
+    private Method orderMethod;
+
+    public ConsumerAnnotationDetector(Class<?> msgHandler, boolean supportsOrder, boolean supportsResponse) {
+        this.msgHandler = msgHandler;
+        // Look for all methods that need to be called when a
+        // message is received.
+        onMessage = new ArrayList<>();
+        onValidate = new ArrayList<>();
+        onResponse = new ArrayList<>();
+        onProcessStep = new HashMap<>();
+        Arrays.stream(ProcessStep.values()).forEach(step -> onProcessStep.put(step, new ArrayList<>()));
+        for (Method m : getAllMethodsInHierarchy(msgHandler)) {
+            if (m.isAnnotationPresent(OnMessage.class))
+                onMessage.add(m);
+            else if (m.isAnnotationPresent(OnValidate.class))
+                onValidate.add(m);
+            else if (m.isAnnotationPresent(Response.class)) {
+                if (!supportsResponse)
+                    throw new RuntimeException("@Response is not supported by the current connector");
+
+                onResponse.add(m);
+            } else if (m.isAnnotationPresent(Order.class)) {
+                if (!supportsOrder)
+                    throw new RuntimeException("@Order is not supported by the current connector");
+
+                orderMethod = m;
+            } else if (m.isAnnotationPresent(On.class) || m.isAnnotationPresent(Ons.class))
+                Arrays.stream(m.getAnnotationsByType(On.class))
+                    .map(on -> on.value())
+                    .distinct()
+                    .forEach(x -> onProcessStep.get(x).add(m));
+        }
+        if (orderMethod != null)
+            orderQueue = new HashMap<>();
+        else
+            orderQueue = null;
+
+        injectFields = new HashMap<>();
+        injectFields.put(Config.class, new HashMap<>());
+        injectFields.put(javax.inject.Inject.class, new HashMap<>());
+        injectFields.put(forklift.decorators.Message.class, new HashMap<>());
+        injectFields.put(forklift.decorators.Headers.class, new HashMap<>());
+        injectFields.put(forklift.decorators.Properties.class, new HashMap<>());
+        injectFields.put(forklift.decorators.Producer.class, new HashMap<>());
+        for (Field f : getAllFieldsInHierarchy(msgHandler)) {
+            injectFields.keySet().forEach(type -> {
+                if (f.isAnnotationPresent(type)) {
+                    f.setAccessible(true);
+
+                    // Init the list
+                    if (injectFields.get(type).get(f.getType()) == null)
+                        injectFields.get(type).put(f.getType(), new ArrayList<>());
+                    injectFields.get(type).get(f.getType()).add(f);
+                }
+            });
+        }
+    }
+
+    private static Method[] getAllMethodsInHierarchy(Class<?> objectClass) {
+        Set<Method> allMethods = new HashSet<Method>();
+        Method[] declaredMethods = objectClass.getDeclaredMethods();
+        Method[] methods = objectClass.getMethods();
+        if (objectClass.getSuperclass() != null) {
+            Class<?> superClass = objectClass.getSuperclass();
+            Method[] superClassMethods = getAllMethodsInHierarchy(superClass);
+            allMethods.addAll(Arrays.asList(superClassMethods));
+        }
+        for (Class<?> interf : objectClass.getInterfaces()) {
+            Method[] interfaceMethods = getAllMethodsInHierarchy(interf);
+            allMethods.addAll(Arrays.asList(interfaceMethods));
+        }
+
+        allMethods.addAll(Arrays.asList(declaredMethods));
+        allMethods.addAll(Arrays.asList(methods));
+        return allMethods.toArray(new Method[allMethods.size()]);
+    }
+
+    private static Field[] getAllFieldsInHierarchy(Class<?> objectClass) {
+        Set<Field> allfields = new HashSet<Field>();
+        Field[] declaredfields = objectClass.getDeclaredFields();
+        Field[] fields = objectClass.getFields();
+        if (objectClass.getSuperclass() != null) {
+            Class<?> superClass = objectClass.getSuperclass();
+            Field[] superClassfields = getAllFieldsInHierarchy(superClass);
+            allfields.addAll(Arrays.asList(superClassfields));
+        }
+        allfields.addAll(Arrays.asList(declaredfields));
+        allfields.addAll(Arrays.asList(fields));
+        return allfields.toArray(new Field[allfields.size()]);
+    }
+    public Map<Class, Map<Class<?>, List<Field>>> getInjectFields() {
+        return injectFields;
+    }
+
+    public Class<?> getMsgHandler() {
+        return msgHandler;
+    }
+
+    public List<Method> getOnMessage() {
+        return onMessage;
+    }
+
+    public List<Method> getOnValidate() {
+        return onValidate;
+    }
+
+    public List<Method> getOnResponse() {
+        return onResponse;
+    }
+
+    public Map<String, List<MessageRunnable>> getOrderQueue() {
+        return orderQueue;
+    }
+
+    public Map<ProcessStep, List<Method>> getOnProcessStep() {
+        return onProcessStep;
+    }
+
+    public Method getOrderMethod() {
+        return orderMethod;
+    }
+
+}

--- a/core/src/main/java/forklift/decorators/On.java
+++ b/core/src/main/java/forklift/decorators/On.java
@@ -8,11 +8,13 @@ import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.lang.annotation.Inherited;
 
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})
 @Repeatable(Ons.class)
+@Inherited
 public @interface On {
     ProcessStep value();
 }

--- a/core/src/main/java/forklift/decorators/OnDeploy.java
+++ b/core/src/main/java/forklift/decorators/OnDeploy.java
@@ -5,9 +5,11 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.lang.annotation.Inherited;
 
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})
+@Inherited
 public @interface OnDeploy {
 }

--- a/core/src/main/java/forklift/decorators/OnMessage.java
+++ b/core/src/main/java/forklift/decorators/OnMessage.java
@@ -5,9 +5,11 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.lang.annotation.Inherited;
 
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})
+@Inherited
 public @interface OnMessage {
 }

--- a/core/src/main/java/forklift/decorators/OnUndeploy.java
+++ b/core/src/main/java/forklift/decorators/OnUndeploy.java
@@ -5,9 +5,11 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.lang.annotation.Inherited;
 
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})
+@Inherited
 public @interface OnUndeploy {
 }

--- a/core/src/main/java/forklift/decorators/OnValidate.java
+++ b/core/src/main/java/forklift/decorators/OnValidate.java
@@ -5,9 +5,11 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.lang.annotation.Inherited;
 
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})
+@Inherited
 public @interface OnValidate {
 }

--- a/core/src/main/java/forklift/decorators/Ons.java
+++ b/core/src/main/java/forklift/decorators/Ons.java
@@ -5,10 +5,12 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.lang.annotation.Inherited;
 
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})
+@Inherited
 public @interface Ons {
     On[] value();
 }

--- a/core/src/test/java/forklift/consumer/ConsumerAnnotationDetectionTest.java
+++ b/core/src/test/java/forklift/consumer/ConsumerAnnotationDetectionTest.java
@@ -1,0 +1,80 @@
+package forklift.consumer;
+
+import static org.junit.Assert.*;
+
+import forklift.decorators.Message;
+import forklift.decorators.On;
+import forklift.decorators.OnMessage;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+
+@RunWith(JUnit4.class)
+public class ConsumerAnnotationDetectionTest {
+    public static class Simple {
+        @On(ProcessStep.Complete) public void complete() {}
+        @On(ProcessStep.Pending) public void pending() {}
+        @Message public String message;
+        @OnMessage public void onMessage() {};
+    }
+
+    public static class Inherited extends Simple {
+    }
+
+    public interface Interface {
+        @On(ProcessStep.Pending) void pending();
+        @OnMessage void onMessage();
+    }
+
+    public static class Implementation implements Interface {
+        @Override public void pending() { }
+        @Override public void onMessage() { }
+    }
+
+    @Test
+    public void testSimpleClass() throws Exception {
+        testAnnotations(Simple.class);
+    }
+
+    @Test
+    public void testInheritedClass() throws Exception {
+        testAnnotations(Inherited.class);
+    }
+
+    public void testAnnotations(Class<?> classy) throws Exception {
+        ConsumerAnnotationDetector detector = new ConsumerAnnotationDetector(classy, false, false);
+        assertEquals(1, detector.getOnMessage().size());
+        assertEquals(classy.getMethod("onMessage"), detector.getOnMessage().get(0));
+
+        assertEquals(1, detector.getInjectFields().get(Message.class).size());
+        List<Field> fields = detector.getInjectFields().get(Message.class).get(String.class);
+        assertEquals(1, fields.size());
+        assertEquals(classy.getField("message"), fields.get(0));
+
+        List<Method> completeMethods = detector.getOnProcessStep().get(ProcessStep.Complete);
+        assertEquals(1, completeMethods.size());
+        assertEquals(classy.getMethod("complete"), completeMethods.get(0));
+
+        List<Method> pendingMethods = detector.getOnProcessStep().get(ProcessStep.Pending);
+        assertEquals(1, pendingMethods.size());
+        assertEquals(classy.getMethod("pending"), pendingMethods.get(0));
+
+        List<Method> errorMethods = detector.getOnProcessStep().get(ProcessStep.Error);
+        assertEquals(0, errorMethods.size());
+    }
+
+    @Test
+    public void testImplementedInterface() throws Exception {
+        ConsumerAnnotationDetector detector = new ConsumerAnnotationDetector(Implementation.class, false, false);
+        assertEquals(1, detector.getOnMessage().size());
+        assertEquals(Interface.class.getMethod("onMessage"), detector.getOnMessage().get(0));
+
+        List<Method> pendingMethods = detector.getOnProcessStep().get(ProcessStep.Pending);
+        assertEquals(1, pendingMethods.size());
+        assertEquals(Interface.class.getMethod("pending"), pendingMethods.get(0));
+    }
+}


### PR DESCRIPTION
For consumers with a high degree of shared boilerplate on consumer methods, creating a base class to abstract the boilerplate fails because the annotations only are detected on direct members of the consumer. Allowing forklift to detect annotations on super classes and interfaces solves this issue. 