### PR TITLE
Perform Acknowledgment After Processing When Working with AMQ

### DIFF
--- a/connectors/kafka/src/main/java/forklift/message/KafkaMessage.java
+++ b/connectors/kafka/src/main/java/forklift/message/KafkaMessage.java
@@ -31,7 +31,7 @@ public class KafkaMessage extends ForkliftMessage {
     }
 
     @Override
-    public boolean acknowledge() throws ConnectorException {
+    public boolean beforeProcessing() throws ConnectorException {
         try {
             final boolean acknowledged = controller.acknowledge(consumerRecord, generationNumber);
             log.debug("Acknoledgment for topic: {} partition: {} offset: {} generation: {} successful: {}",

--- a/connectors/kafka/src/test/java/forklift/message/KafkaMessageTests.java
+++ b/connectors/kafka/src/test/java/forklift/message/KafkaMessageTests.java
@@ -30,20 +30,20 @@ public class KafkaMessageTests {
     }
 
     @Test
-    public void acknowledgeFalseTest() throws ConnectorException, InterruptedException {
+    public void beforeProcessingFalseTest() throws ConnectorException, InterruptedException {
         when(controller.acknowledge(eq(record), any(Integer.class))).thenReturn(false);
 
-        boolean acknowledged = message.acknowledge();
+        boolean acknowledged = message.beforeProcessing();
 
         assertFalse(acknowledged);
         verify(controller).acknowledge(eq(record), any(Integer.class));
     }
 
     @Test
-    public void acknowledgeCallsControllerSuccess() throws ConnectorException, InterruptedException {
+    public void beforeProcessingCallsControllerSuccess() throws ConnectorException, InterruptedException {
         when(controller.acknowledge(eq(record), any(Integer.class))).thenReturn(true);
 
-        boolean acknowledged = message.acknowledge();
+        boolean acknowledged = message.beforeProcessing();
 
         assertTrue(acknowledged);
         verify(controller).acknowledge(eq(record), any(Integer.class));

--- a/core/src/main/java/forklift/connectors/ForkliftMessage.java
+++ b/core/src/main/java/forklift/connectors/ForkliftMessage.java
@@ -24,7 +24,23 @@ public class ForkliftMessage {
         this.setMsg(msg);
     }
 
-    public boolean acknowledge() throws ConnectorException {
+
+    /**
+     * Callback after this message is processed.
+     *
+     * @return whether the message was successfully acknowledged.
+     */
+    public boolean acknowledge() {
+        return true;
+    }
+
+    /**
+     * Callback before this message is processed.
+     *
+     * @throws ConnectorException when there is an unexpected error
+     * @return whether to continue processing this message.
+     */
+    public boolean beforeProcessing() throws ConnectorException {
         return true;
     }
 

--- a/core/src/main/java/forklift/consumer/wrapper/RoleInputMessage.java
+++ b/core/src/main/java/forklift/consumer/wrapper/RoleInputMessage.java
@@ -166,7 +166,14 @@ public class RoleInputMessage {
         }
 
         @Override
-        public boolean acknowledge() throws ConnectorException {
+        public boolean beforeProcessing() throws ConnectorException {
+            if (sourceMessage == null)
+                return true;
+            return sourceMessage.beforeProcessing();
+        }
+
+        @Override
+        public boolean acknowledge() {
             if (sourceMessage == null)
                 return true;
             return sourceMessage.acknowledge();


### PR DESCRIPTION
#### Changes:
- Split `ForkliftMessage` acknowledgment into two pieces, one which runs beforehand and can signal messages to be skipped and the other which runs after and is expected to always succeed.

#### Release Note:
- Made ActiveMQ consumers acknowledge messages after they are processed so as to provide at-least-once processing and avoid dropping messages.

#### Testing:
- Tested replay and retry for both AMQ and forklift using a short timeout (10 seconds).
    - Noted that messages themselves go over the same queues (the original queue initilaly, and then the role queue for any subsequent messges) and get consumed properly (testing the changes to acknowledging message).
    - Noted that the proper entries appear in `forklift-replay` and `forklift-retry` in elasticsearch. That is, the replay index had a message with the message's ID and a status of `RETRYING` while the message was being retried, and a status of `ERROR` after that. In the retry index there was a log in the retry index for the corresponding message ID only when the message was being retried.
    - For the kafka-connector, with debug logging enabled, I noted that acknowledgment messges re indeed printed before the message is processed.
    
- Tested that acknowledgments after processing protect from spontaneous crashes in ActiveMQ. 
   - Verified that the if I force quit the application in the consumer's long processing time, the message doesn't get acked (still shows up in the admin UI), and then gets reprocessed when the application starts up again.
    - Verified that the application does get acked and not reprocessed in normal (non-crashing) processing.

- Used this consumer code on forklift-server (ActiveMQ) for ack testing:
```java
@MultiThreaded(3)
@Queue("test")
@Replay
@RoleInput
@Retry(maxRetries=5, timeout=10)
public class TestConsumer {
    private static final Logger log = LoggerFactory.getLogger(TestConsumer.class);

    @Message public String message;

    @OnMessage
    public void onMessage() {
        log.info("Starting test processing: {}", message);

        try {
            Thread.sleep(10000);
        } catch (final InterruptedException e) {}

        log.info("Finished test processing: {}", message);
    }
}
```




After considerable discussion with @AFrieze and @nateww, I think it makes sense to say a few things to justify these changes:

- The typical and original usage of AMQ with forklift was to perform a piece of work reliably for a business process, where missing a message means that a process is unfulfilled.
- Crashes in most applications are inevitable (although their rarity can be debated).
- The change from acknowledging post-processing to pre-processing was made haphazardly, without considering missed messages.
- The kafka connector doesn't fit cleanly into this with the current threading model, and has been documented to be have an at-least-once processing guarantee.

Thus my conclusion is to let the Kafka connector continue to perform at-most-once processing, but change how AMQ is used to work with the original expectation of at-least-once processing. 

---

Please Review: @dcshock @AFrieze @nateww 
