### PR TITLE
Sofi-99339 Add username and password to command line args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ RUN apk add --no-cache bash
 
 # Add forklift server
 WORKDIR /tmp
-ADD server/target/universal/forklift-server-2.2.zip forklift.zip
+ADD server/target/universal/forklift-server-3.7.zip forklift.zip
 RUN yes | unzip -d /usr/local forklift.zip
-RUN ln -s /usr/local/forklift-server-2.2 /usr/local/forklift
+RUN ln -s /usr/local/forklift-server-3.7 /usr/local/forklift
 
 RUN rm forklift.zip
 RUN mkdir -p /usr/local/forklift/consumers

--- a/README.adoc
+++ b/README.adoc
@@ -10,6 +10,9 @@ link:doc/forklift.adoc[Documentation]
 == Releases
 link:doc/prev_releases.adoc[Previous Releases]
 
+* *June 13th 2019* - v3.7
+** Add support for password-based authentication to forklift server.
+
 * *April 5th 2019* - v3.6
 ** Add support for password-based authentication to the ActiveMQ connector.
 
@@ -60,7 +63,7 @@ link:doc/prev_releases.adoc[Previous Releases]
 == Current Release Dependencies
 === SBT
 ----
-libraryDependencies += "com.github.dcshock" % "forklift-server" % "2.0"
+libraryDependencies += "com.github.dcshock" % "forklift-server" % "3.7"
 ----
 
 === Maven

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val baseSettings = Seq(
   organization := "com.github.dcshock",
-  version := "3.6",
+  version := "3.7",
   scalaVersion := "2.11.7",
   javacOptions ++= Seq("-source", "1.8"),
   javacOptions in compile ++= Seq("-g:lines,vars,source", "-deprecation"),

--- a/server/src/main/java/forklift/ForkliftOpts.java
+++ b/server/src/main/java/forklift/ForkliftOpts.java
@@ -12,6 +12,12 @@ public class ForkliftOpts {
     @Option(name="-url", required=true, usage="broker connection url")
     private String brokerUrl;
 
+    @Option(name="-username", depends = "-password", usage = "username for broker connection")
+    private String username;
+
+    @Option(name="-password", depends = "-username", usage = "password for broker connection")
+    private String password;
+
     @Option(name="-retryDir", usage="directory for persisted retry messages")
     private String retryDir;
 
@@ -63,6 +69,14 @@ public class ForkliftOpts {
 
     public String getBrokerUrl() {
         return brokerUrl;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
     }
 
     public void setBrokerUrl(String brokerUrl) {

--- a/server/src/main/java/forklift/ForkliftServer.java
+++ b/server/src/main/java/forklift/ForkliftServer.java
@@ -5,7 +5,6 @@ import consul.Consul;
 import forklift.connectors.ActiveMQConnector;
 import forklift.connectors.ForkliftConnectorI;
 import forklift.consumer.ConsumerDeploymentEvents;
-import forklift.decorators.*;
 import forklift.deployment.Deployment;
 import forklift.deployment.DeploymentManager;
 import forklift.deployment.DeploymentWatch;
@@ -327,6 +326,6 @@ public final class ForkliftServer {
             broker.start();
         }
         log.info("Connected to broker on " + brokerUrl);
-        return new ActiveMQConnector(brokerUrl);
+        return new ActiveMQConnector(brokerUrl, opts.getUsername(), opts.getPassword());
     }
 }


### PR DESCRIPTION
### Changes
* Add username and password to command line args for forklift-server so we can connect to AMQ that requires a username and password. This will enable us to run forklift-server connecting to AWS AMQ.
* Update forklift version to 3.7

### Testing
* Tested running forklift-server with:
`forklift-server -url $ACTIVEMQ_OPENWIRE -monitor1 /usr/local/forklift/consumers -monitor2 /config -retryESHost $FORKLIFT_ES_HOST -retryESPort $FORKLIFT_ES_PORT -replayESHost $FORKLIFT_ES_HOST -replayESPort $FORKLIFT_ES_PORT $FORKLIFT_RETRIES` 
* `forklift-server -url $ACTIVEMQ_OPENWIRE -username $SECRET_SERVICE_AMQ_AMQ_USERNAME -password $SECRET_SERVICE_AMQ_AMQ_PASSWORD -monitor1 /usr/local/forklift/consumers -monitor2 /config -retryESHost $FORKLIFT_ES_HOST -retryESPort $FORKLIFT_ES_PORT -replayESHost $FORKLIFT_ES_HOST -replayESPort $FORKLIFT_ES_PORT $FORKLIFT_RETRIES`
and both worked with no errors