### PR TITLE
Downgrade to 5.15.12 for compatibility with AWS.

### DIFF
--- a/connectors/activemq/build.gradle
+++ b/connectors/activemq/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
     api project(':forklift-core'),
-            'org.apache.activemq:activemq-client:5.16.0',
+            'org.apache.activemq:activemq-client:5.15.12',
             'org.apache.geronimo.specs:geronimo-jms_1.1_spec:1.1.1'
 
     testImplementation 'commons-io:commons-io:2.7',
-            'org.apache.activemq:activemq-all:5.16.0'
+            'org.apache.activemq:activemq-all:5.15.12'
 }


### PR DESCRIPTION
While 5.16.0 is the latest version of ActiveMQ and our tests pass with this version; Amazon's hosted ActiveMQ solution is currently only at 5.15.12. Downgrading so those using the hosted solution won't run into conflicts.